### PR TITLE
Fixes for handling imported yaml and apex

### DIFF
--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -430,8 +430,6 @@ func main() {
 
 	m := mesh.New(tracer)
 
-	m.Link(runtime.NewInvoker(log, processor.GetProviders(), msgpackcodec))
-
 	for _, comp := range config.Compute {
 		computeLoader, ok := computeRegistry[comp.Uses]
 		if !ok {
@@ -451,6 +449,8 @@ func main() {
 		log.Error(err, "Could not initialize processor")
 		os.Exit(1)
 	}
+
+	m.Link(runtime.NewInvoker(log, processor.GetProviders(), msgpackcodec))
 
 	for _, subscription := range config.Subscriptions {
 		pubsub, err := resource.Get[proto.PubSubClient](resources, subscription.Resource)

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -428,11 +428,6 @@ func main() {
 		return []byte{}, nil
 	}
 
-	if err = processor.Initialize(); err != nil {
-		log.Error(err, "Could not initialize processor")
-		os.Exit(1)
-	}
-
 	m := mesh.New(tracer)
 
 	m.Link(runtime.NewInvoker(log, processor.GetProviders(), msgpackcodec))
@@ -451,6 +446,11 @@ func main() {
 		m.Link(invoker)
 	}
 	dependencies["compute:mesh"] = m
+
+	if err = processor.Initialize(); err != nil {
+		log.Error(err, "Could not initialize processor")
+		os.Exit(1)
+	}
 
 	for _, subscription := range config.Subscriptions {
 		pubsub, err := resource.Get[proto.PubSubClient](resources, subscription.Resource)

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -166,7 +166,7 @@ func main() {
 	}
 
 	// Load the configuration
-	config, err := loadConfiguration(busFile)
+	config, err := loadConfiguration(busFile, log)
 	if err != nil {
 		log.Error(err, "could not load configuration", "file", busFile)
 		os.Exit(1)
@@ -796,7 +796,7 @@ func main() {
 // 	return output, nil
 // }
 
-func loadConfiguration(filename string) (*runtime.Configuration, error) {
+func loadConfiguration(filename string, log logr.Logger) (*runtime.Configuration, error) {
 	// TODO: Load from file or URI
 	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
 	if err != nil {
@@ -816,14 +816,17 @@ func loadConfiguration(filename string) (*runtime.Configuration, error) {
 	}
 
 	for _, imp := range c.Import {
+		fileDir := filepath.Dir(imp)
 		path := filepath.Join(baseDir, imp)
+		log.Info("Importing config " + path)
 		dir := filepath.Dir(path)
 		runtime.SetConfigBaseDir(dir)
-		imported, err := loadConfiguration(path)
+		imported, err := loadConfiguration(path, log)
 		if err != nil {
 			return nil, err
 		}
-		runtime.Combine(c, imported)
+		runtime.Combine(c, fileDir, log, imported)
+		runtime.SetConfigBaseDir(baseDir)
 	}
 
 	return c, nil

--- a/spec/apex/apex.go
+++ b/spec/apex/apex.go
@@ -3,6 +3,7 @@ package apex
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/apexlang/apex-go/ast"
 	"github.com/apexlang/apex-go/parser"
@@ -28,6 +29,7 @@ func Loader(ctx context.Context, with interface{}, resolveAs resolve.ResolveAs) 
 	c := Config{
 		Filename: "spec.apexlang",
 	}
+
 	if err := config.Decode(with, &c); err != nil {
 		return nil, err
 	}
@@ -57,6 +59,15 @@ func Parse(schema []byte) (*spec.Namespace, error) {
 		Options: parser.ParseOptions{
 			NoLocation: true,
 			NoSource:   true,
+			Resolver: func(location string, from string) (string, error) {
+				if strings.HasPrefix(location, "@") {
+					// what do?
+					return "", nil
+				} else {
+					src, err := os.ReadFile(location)
+					return string(src), err
+				}
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This PR
- fixes importing dependencies from relative imports (e.g. importing `./sub/dir/bus.yaml` which in turn depends on `file.wasm`).
- adds a resolver to the apex to resolve local apex files.

This PR may not be mergable. The two fixes may be better fixed in a more holistic manner, but I'm deferring to @pkedy there.