### PR TITLE
GoReleaser with docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           fetch-depth: 0
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
         name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,14 +2,18 @@ project_name: nanobus
 builds:
   - id: nanobus
     main: ./cmd/nanobus
-    binary: "{{ .ProjectName }}"
+    binary: nanobus
     goos:
       - linux
       - darwin
       - windows
+      - freebsd
     goarch:
       - amd64
       - arm64
+    goarm:
+      - 6
+      - 7
     ldflags:
       - -s -w -X main.Version={{.Version}} -X main.Commit={{.Commit}} -X main.Date={{.Date}}
     env:
@@ -39,6 +43,61 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+dockers:
+  - image_templates:
+      - 'nanobus/nanobus:{{ .Tag }}-amd64'
+      # - 'ghcr.io/nanobus/nanobus:{{ .Tag }}-amd64'
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=io.artifacthub.package.readme-url=https://raw.githubusercontent.com/nanobus/nanobus/main/README.md"
+      - "--label=io.artifacthub.package.logo-url=https://raw.githubusercontent.com/nanobus/nanobus/main/logo.png"
+      - "--label=io.artifacthub.package.license=MIT"
+      - "--label=org.opencontainers.image.description=A lightweight microservice runtime that reduces developer responsibility so that teams can focus on core application logic"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - 'nanobus/nanobus:{{ .Tag }}-arm64v8'
+      # - 'ghcr.io/nanobus/nanobus:{{ .Tag }}-arm64'
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=io.artifacthub.package.readme-url=https://raw.githubusercontent.com/nanobus/nanobus/main/README.md"
+      - "--label=io.artifacthub.package.logo-url=https://raw.githubusercontent.com/nanobus/nanobus/main/logo.png"
+      - "--label=io.artifacthub.package.license=MIT"
+      - "--label=org.opencontainers.image.description=A lightweight microservice runtime that reduces developer responsibility so that teams can focus on core application logic"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64/v8"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: 'nanobus/nanobus:{{ .Tag }}'
+    image_templates:
+      - 'nanobus/nanobus:{{ .Tag }}-amd64'
+      - 'nanobus/nanobus:{{ .Tag }}-arm64v8'
+  # - name_template: 'ghcr.io/nanobus/nanobus:{{ .Tag }}'
+  #   image_templates:
+  #     - 'ghcr.io/nanobus/nanobus:{{ .Tag }}-amd64'
+  #     - 'ghcr.io/nanobus/nanobus:{{ .Tag }}-arm64v8'
+  - name_template: 'nanobus/nanobus:latest'
+    image_templates:
+      - 'nanobus/nanobus:{{ .Tag }}-amd64'
+      - 'nanobus/nanobus:{{ .Tag }}-arm64v8'
+  # - name_template: 'ghcr.io/nanobus/nanobus:latest'
+  #   image_templates:
+  #     - 'ghcr.io/nanobus/nanobus:{{ .Tag }}-amd64'
+  #     - 'ghcr.io/nanobus/nanobus:{{ .Tag }}-arm64v8'
 
 # brews:
 #   - name: NanoBus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY nanobus /app/nanobus
+WORKDIR /app
+ENTRYPOINT ["/app/nanobus"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY nanobus /app/nanobus
+WORKDIR /app
+ENTRYPOINT ["/app/nanobus"]

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/cc
-COPY /dist/linux-darwin_linux_amd64_v1/nanobus /app/nanobus
+COPY /dist/nanobus_linux_amd64_v1/nanobus /app/nanobus
 WORKDIR /app
 ENTRYPOINT ["/app/nanobus"]

--- a/docker/Dockerfile-java11
+++ b/docker/Dockerfile-java11
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/java11-debian11
-COPY /dist/linux-darwin_linux_amd64_v1/nanobus /app/nanobus
+COPY /dist/nanobus_linux_amd64_v1/nanobus /app/nanobus
 WORKDIR /app
 ENTRYPOINT ["/app/nanobus"]

--- a/docker/Dockerfile-java17
+++ b/docker/Dockerfile-java17
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/java17-debian11
-COPY /dist/linux-darwin_linux_amd64_v1/nanobus /app/nanobus
+COPY /dist/nanobus_linux_amd64_v1/nanobus /app/nanobus
 WORKDIR /app
 ENTRYPOINT ["/app/nanobus"]

--- a/docker/Dockerfile-nodejs:16
+++ b/docker/Dockerfile-nodejs:16
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/nodejs:16
-COPY /dist/linux-darwin_linux_amd64_v1/nanobus /app/nanobus
+COPY /dist/nanobus_linux_amd64_v1/nanobus /app/nanobus
 WORKDIR /app
 ENTRYPOINT ["/app/nanobus"]

--- a/docker/Dockerfile-python3
+++ b/docker/Dockerfile-python3
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/python3
-COPY /dist/linux-darwin_linux_amd64_v1/nanobus /app/nanobus
+COPY /dist/nanobus_linux_amd64_v1/nanobus /app/nanobus
 WORKDIR /app
 ENTRYPOINT ["/app/nanobus"]


### PR DESCRIPTION
This PR updates the GoReleaser configuration to publish amd64 and arm64v8 images to docker hub.