### PR TITLE
Make CORS configurable

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -618,7 +618,7 @@ func Start(info *Info) error {
 			middlewares = append(middlewares, middleware)
 		}
 	}
-	dependencies["middleare:lookup"] = middlewares
+	dependencies["middleware:lookup"] = middlewares
 
 	translateError := func(err error) *errorz.Error {
 		if errz, ok := err.(*errorz.Error); ok {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -86,13 +86,21 @@ import (
 
 	// TRANSPORTS
 	"github.com/nanobus/nanobus/transport"
+	"github.com/nanobus/nanobus/transport/httprpc"
+	"github.com/nanobus/nanobus/transport/nats"
+	"github.com/nanobus/nanobus/transport/rest"
+
+	// TRANSPORT - FILTERS
 	"github.com/nanobus/nanobus/transport/filter"
 	"github.com/nanobus/nanobus/transport/filter/jwt"
 	"github.com/nanobus/nanobus/transport/filter/session"
 	"github.com/nanobus/nanobus/transport/filter/userinfo"
-	"github.com/nanobus/nanobus/transport/httprpc"
-	"github.com/nanobus/nanobus/transport/nats"
-	"github.com/nanobus/nanobus/transport/rest"
+
+	// TRANSPORT - MIDDLEWARE
+	"github.com/nanobus/nanobus/transport/middleware"
+	middleware_cors "github.com/nanobus/nanobus/transport/middleware/cors"
+
+	// TRANSPORT - ROUTES
 	"github.com/nanobus/nanobus/transport/routes"
 	"github.com/nanobus/nanobus/transport/routes/oauth2"
 )
@@ -193,6 +201,11 @@ func Start(info *Info) error {
 		jwt.JWT,
 		session.Session,
 		userinfo.UserInfo,
+	)
+
+	middlewareRegistry := middleware.Registry{}
+	middlewareRegistry.Register(
+		middleware_cors.Cors,
 	)
 
 	// Compute registration
@@ -586,6 +599,26 @@ func Start(info *Info) error {
 		}
 	}
 	dependencies["filter:lookup"] = filters
+
+	middlewares := []middleware.Middleware{}
+	if configMiddlewares, ok := config.Middleware["http"]; ok {
+		for _, f := range configMiddlewares {
+			middlewareLoader, ok := middlewareRegistry[f.Uses]
+			if !ok {
+				log.Error(nil, "could not find middleware", "type", f.Uses)
+				return errors.New("could not find middleware")
+			}
+
+			middleware, err := middlewareLoader(ctx, f.With, resolveAs)
+			if err != nil {
+				log.Error(err, "could not load middleware", "type", f.Uses)
+				return err
+			}
+
+			middlewares = append(middlewares, middleware)
+		}
+	}
+	dependencies["middleare:lookup"] = middlewares
 
 	translateError := func(err error) *errorz.Error {
 		if errz, ok := err.(*errorz.Error); ok {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -329,7 +329,7 @@ func Start(info *Info) error {
 		loader, ok := specRegistry[spec.Uses]
 		if !ok {
 			log.Error(nil, "Could not find spec", "type", spec.Uses)
-			return errors.New("Could not find spec")
+			return errors.New("could not find spec")
 		}
 		nss, err := loader(ctx, spec.With, resolveAs)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/rbretecher/go-postman-collection v0.9.0
+	github.com/rs/cors v1.8.2
 	github.com/sony/gobreaker v0.5.0
 	github.com/spf13/cast v1.5.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1121,6 +1121,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
+github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=

--- a/runtime/configuration.go
+++ b/runtime/configuration.go
@@ -23,6 +23,7 @@ type Configuration struct {
 	Transports    map[string]Component       `json:"transports" yaml:"transports"`
 	Tracing       *Component                 `json:"tracing" yaml:"tracing"`
 	Specs         []Component                `json:"specs" yaml:"specs"`
+	Middleware    map[string][]Component     `json:"middleware" yaml:"middleware"`
 	Filters       map[string][]Component     `json:"filters" yaml:"filters"`
 	Codecs        map[string]Component       `json:"codecs" yaml:"codecs"`
 	Resources     map[string]Component       `json:"resources" yaml:"resources"`

--- a/transport/middleware/cors/cors.go
+++ b/transport/middleware/cors/cors.go
@@ -1,0 +1,116 @@
+package cors
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rs/cors"
+
+	"github.com/nanobus/nanobus/config"
+	"github.com/nanobus/nanobus/resolve"
+	"github.com/nanobus/nanobus/transport/middleware"
+)
+
+type CorsConfig struct {
+	// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+	// If the special "*" value is present in the list, all origins will be allowed.
+	// An origin may contain a wildcard (*) to replace 0 or more characters
+	// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
+	// Only one wildcard can be used per origin.
+	// Default value is ["*"]
+	AllowedOrigins []string `mapstructure:"allowedOrigins"`
+	// AllowedMethods is a list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+	AllowedMethods []string `mapstructure:"allowedMethods"`
+	// AllowedHeaders is list of non simple headers the client is allowed to use with
+	// cross-domain requests.
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
+	AllowedHeaders []string `mapstructure:"allowedHeaders"`
+	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+	// API specification
+	ExposedHeaders []string `mapstructure:"exposedHeaders"`
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached
+	MaxAge int `mapstructure:"maxAge"`
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool `mapstructure:"allowCredentials"`
+	// OptionsPassthrough instructs preflight to let other potential next handlers to
+	// process the OPTIONS method. Turn this on if your application handles OPTIONS.
+	OptionsPassthrough bool `mapstructure:"optionsPassthrough"`
+	// Provides a status code to use for successful OPTIONS requests.
+	// Default value is http.StatusNoContent (204).
+	OptionsSuccessStatus int `mapstructure:"optionsSuccessStatus"`
+	// Debugging flag adds additional output to debug server side CORS issues
+	Debug bool `mapstructure:"debug"`
+
+	// DevMode forces AllowedOrigins to *, AllowCredentials to true, and allows reflection
+	// of the request Origin header. This works around a security protection embedded into
+	// the standard that makes clients to refuse such configuration.
+	// Obviously, this setting being set to true is only intended for development.
+	DevMode bool `mapstructure:"devMode"`
+}
+
+// Cors is the NamedLoader for the cors middleware.
+func Cors() (string, middleware.Loader) {
+	return "cors/v1", CorsLoader
+}
+
+func CorsLoader(ctx context.Context, with interface{}, resolver resolve.ResolveAs) (middleware.Middleware, error) {
+	c := CorsConfig{
+		AllowedOrigins: []string{"*"},
+		// "PUT", "PATCH", "DELETE" are commonly needed in REST APIs however
+		// the defaults are aligned with the cors library defaults.
+		AllowedMethods: []string{"HEAD", "GET", "POST"},
+	}
+	if err := config.Decode(with, &c); err != nil {
+		return nil, err
+	}
+
+	corsOptions := cors.Options{
+		AllowedOrigins:       c.AllowedOrigins,
+		AllowedMethods:       c.AllowedMethods,
+		AllowedHeaders:       c.AllowedHeaders,
+		ExposedHeaders:       c.ExposedHeaders,
+		MaxAge:               c.MaxAge,
+		AllowCredentials:     c.AllowCredentials,
+		OptionsPassthrough:   c.OptionsPassthrough,
+		OptionsSuccessStatus: c.OptionsSuccessStatus,
+		Debug:                c.Debug,
+	}
+
+	if c.DevMode {
+		corsOptions.AllowedOrigins = []string{"*"}
+		corsOptions.AllowCredentials = true
+
+		// Documentation from github.com/rs/cors
+		//
+		// ### Allow * With Credentials Security Protection
+		//
+		// This library has been modified to avoid a well known security
+		//  issue when configured with `AllowedOrigins` to `*` and
+		// `AllowCredentials` to `true`. Such setup used to make the library
+		// reflects the request `Origin` header value, working around a
+		// security protection embedded into the standard that makes clients
+		// to refuse such configuration. This behavior has been removed with
+		// [#55](https://github.com/rs/cors/issues/55) and
+		// [#57](https://github.com/rs/cors/issues/57).
+		//
+		// If you depend on this behavior and understand the implications, you
+		// can restore it using the
+		// `AllowOriginFunc` with `func(origin string) {return true}`.
+		//
+		// Please refer to [#55](https://github.com/rs/cors/issues/55) for
+		// more information about the security implications.
+		corsOptions.AllowOriginFunc = func(origin string) bool { return true }
+	}
+
+	return CorsHandler(corsOptions), nil
+}
+
+func CorsHandler(options cors.Options) middleware.Middleware {
+	return func(h http.Handler) http.Handler {
+		return cors.New(options).Handler(h)
+	}
+}

--- a/transport/middleware/cors/cors.go
+++ b/transport/middleware/cors/cors.go
@@ -54,7 +54,7 @@ type CorsConfig struct {
 
 // Cors is the NamedLoader for the cors middleware.
 func Cors() (string, middleware.Loader) {
-	return "cors/v1", CorsLoader
+	return "cors/v0", CorsLoader
 }
 
 func CorsLoader(ctx context.Context, with interface{}, resolver resolve.ResolveAs) (middleware.Middleware, error) {

--- a/transport/middleware/cors/cors.go
+++ b/transport/middleware/cors/cors.go
@@ -81,7 +81,7 @@ func CorsLoader(ctx context.Context, with interface{}, resolver resolve.ResolveA
 	}
 
 	if c.DevMode {
-		corsOptions.AllowedOrigins = []string{"*"}
+		corsOptions.AllowedOrigins = []string{}
 		corsOptions.AllowCredentials = true
 
 		// Documentation from github.com/rs/cors

--- a/transport/middleware/middleware.go
+++ b/transport/middleware/middleware.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/nanobus/nanobus/registry"
+)
+
+type (
+	NamedLoader = registry.NamedLoader[Middleware]
+	Loader      = registry.Loader[Middleware]
+	Registry    = registry.Registry[Middleware]
+
+	Middleware func(h http.Handler) http.Handler
+)

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	"github.com/nanobus/nanobus/channel"
-	"github.com/nanobus/nanobus/config"
-	"github.com/nanobus/nanobus/resolve"
 	"github.com/nats-io/nats.go"
 	"go.uber.org/multierr"
 
+	"github.com/nanobus/nanobus/channel"
+	"github.com/nanobus/nanobus/config"
 	"github.com/nanobus/nanobus/errorz"
+	"github.com/nanobus/nanobus/resolve"
 	"github.com/nanobus/nanobus/spec"
 	"github.com/nanobus/nanobus/transport"
 	"github.com/nanobus/nanobus/transport/filter"

--- a/transport/rest/rest.go
+++ b/transport/rest/rest.go
@@ -129,6 +129,12 @@ type CorsConfig struct {
 	OptionsSuccessStatus int `mapstructure:"optionsSuccessStatus"`
 	// Debugging flag adds additional output to debug server side CORS issues
 	Debug bool `mapstructure:"debug"`
+
+	// DevMode forces AllowedOrigins to *, AllowCredentials to true, and allows reflection
+	// of the request Origin header. This works around a security protection embedded into
+	// the standard that makes clients to refuse such configuration.
+	// Obviously, this setting being set to true is only intended for development.
+	DevMode bool `mapstructure:"devMode"`
 }
 
 type Documentation struct {
@@ -259,6 +265,12 @@ func New(log logr.Logger, tracer trace.Tracer, config Configuration, namespaces 
 		OptionsPassthrough:   config.Cors.OptionsPassthrough,
 		OptionsSuccessStatus: config.Cors.OptionsSuccessStatus,
 		Debug:                config.Cors.Debug,
+	}
+
+	if config.Cors.DevMode {
+		corsOptions.AllowedOrigins = []string{"*"}
+		corsOptions.AllowCredentials = true
+		corsOptions.AllowOriginFunc = func(origin string) bool { return true }
 	}
 
 	rest := Rest{

--- a/transport/rest/rest.go
+++ b/transport/rest/rest.go
@@ -400,7 +400,7 @@ func (t *Rest) Listen() error {
 	t.log.Info("REST server listening", "address", t.address)
 
 	handler := otelhttp.NewHandler(t.router, "rest")
-	handler = cors.Default().Handler(handler)
+	handler = cors.AllowAll().Handler(handler)
 	return http.Serve(ln, handler)
 }
 

--- a/transport/routes/oauth2/oauth2.go
+++ b/transport/routes/oauth2/oauth2.go
@@ -302,7 +302,12 @@ func setSessionCookie(w http.ResponseWriter, token *oauth2.Token, claims map[str
 		return errors.New("sid claim is not a string")
 	}
 
-	cookie := http.Cookie{Name: "sid", Value: sid, Expires: token.Expiry, Path: "/"}
+	cookie := http.Cookie{
+		Name:    "sid",
+		Value:   sid,
+		Expires: token.Expiry,
+		Path:    "/",
+	}
 	http.SetCookie(w, &cookie)
 
 	return nil


### PR DESCRIPTION
This PR switches the Rest transport to using the [github.com/rs/cors](https://github.com/rs/cors) library which has great configurability. The transport has settings to apply for CORS and follows the settings and defaults of the library.

/cc @jsoverson