### PR TITLE
Transport invoker authorization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ Create a file called `bus.yaml` with the following contents:
 ```yaml
 id: hello-world
 version: 0.0.1
-# All operations are authorized before execution
-# and are denied by default.
-authorization:
-  Greeter:
-    sayHello:
-      unauthenticated: true
 interfaces:
   Greeter:
     sayHello:

--- a/pkg/transport/http/router/rest/rest.go
+++ b/pkg/transport/http/router/rest/rest.go
@@ -440,7 +440,7 @@ func (t *Rest) handler(iface, operation string, isActor bool,
 			}
 		}
 
-		response, err := t.invoker(ctx, iface, id, operation, input)
+		response, err := t.invoker(ctx, iface, id, operation, input, transport.PerformAuthorization)
 		if err != nil {
 			code := http.StatusInternalServerError
 			if errors.Is(err, transport.ErrBadInput) {

--- a/pkg/transport/http/router/router/router.go
+++ b/pkg/transport/http/router/router/router.go
@@ -163,7 +163,7 @@ func (t *Router) handler(h handler.Handler, desiredCodec channel.Codec) http.Han
 			}
 		}
 
-		response, err := t.invoker(ctx, h.Interface, id, h.Operation, input)
+		response, err := t.invoker(ctx, h.Interface, id, h.Operation, input, transport.PerformAuthorization)
 		if err != nil {
 			code := http.StatusInternalServerError
 			if errors.Is(err, transport.ErrBadInput) {

--- a/pkg/transport/httprpc/httprpc.go
+++ b/pkg/transport/httprpc/httprpc.go
@@ -190,7 +190,7 @@ func (t *HTTPRPC) handler(w http.ResponseWriter, r *http.Request) {
 		input = map[string]interface{}{}
 	}
 
-	response, err := t.invoker(ctx, iface, id, operation, input)
+	response, err := t.invoker(ctx, iface, id, operation, input, transport.PerformAuthorization)
 	if err != nil {
 		code := http.StatusInternalServerError
 		if errors.Is(err, transport.ErrBadInput) {

--- a/pkg/transport/nats/nats.go
+++ b/pkg/transport/nats/nats.go
@@ -216,7 +216,7 @@ func (t *NATS) handler(m *nats.Msg) {
 		input = map[string]interface{}{}
 	}
 
-	response, err := t.invoker(ctx, iface, id, operation, input)
+	response, err := t.invoker(ctx, iface, id, operation, input, transport.PerformAuthorization)
 	if err != nil {
 		code := http.StatusInternalServerError
 		if errors.Is(err, transport.ErrBadInput) {

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -26,9 +26,16 @@ type (
 		Close() error
 	}
 
-	Invoker func(ctx context.Context, iface, id, operation string, input interface{}) (interface{}, error)
+	Invoker func(ctx context.Context, iface, id, operation string, input interface{}, authorization Authorization) (interface{}, error)
 
 	Registry map[string]Loader
+)
+
+type Authorization int
+
+const (
+	PerformAuthorization Authorization = 1
+	BypassAuthorization  Authorization = 999
 )
 
 func (r Registry) Register(loaders ...NamedLoader) {


### PR DESCRIPTION
For some transports, like PubSub or CRON triggers, it does not make sense to perform authorization checks against claims (mainly because there aren't any - a user did not trigger it). This PR adds an authorization parameter to transport.Invoker to perform or bypass authorization checks. This also removes the requirement of authorizations for invoking operations from the CLI.