### PR TITLE
Fixes/Updates for docs

### DIFF
--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -72,9 +72,9 @@ func (c *defaultRunCmd) Run() error {
 type runCmd struct {
 	DeveloperMode bool `name:"developer-mode" help:"Enables developer mode."`
 	// BusFile of the application as a configuration file or OCI image reference.
-	BusFile string `arg:"" default:"bus.yaml" help:"The application configuration or OCI image reference"`
+	BusFile string `name:"bus" default:"bus.yaml" help:"The application configuration or OCI image reference"`
 	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
-	ResourcesFile string `arg:"" default:"resources.yaml" help:"The resources configuration"`
+	ResourcesFile string `name:"resources" default:"resources.yaml" help:"The resources configuration"`
 	// Args are arguments passed to the application.
 	Args []string `arg:"" optional:"" help:"Arguments to pass to the application"`
 }
@@ -110,20 +110,20 @@ func (c *runCmd) Run() error {
 
 type invokeCmd struct {
 	DeveloperMode bool `name:"developer-mode" help:"Enables developer mode."`
-	// BusFile is the application configuration (not an OCI image reference).
-	BusFile string `arg:"" default:"bus.yaml" help:"The NanoBus application configuration"`
-	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
-	ResourcesFile string `arg:"" default:"resources.yaml" help:"The resources configuration"`
 	// Interface is the operation's interface.
-	Interface string `required:"" help:"The namespace of the operation to invoke"`
+	Interface string `arg:"" required:"" help:"The namespace of the operation to invoke"`
 	// Operation is the operation name.
-	Operation string `required:"" help:"The operation or function invoke"`
+	Operation string `arg:"" required:"" help:"The operation or function invoke"`
+	// BusFile is the application configuration (not an OCI image reference).
+	BusFile string `name:"bus" default:"bus.yaml" help:"The NanoBus application configuration"`
+	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
+	ResourcesFile string `name:"resources" default:"resources.yaml" help:"The resources configuration"`
 	// EntityID is the entity identifier to invoke.
 	EntityID string `name:"id" optional:"" help:"The entity ID to invoke (e.g. actor ID)"`
 	// Input is the file to use as JSON input.
 	Input string `arg:"" optional:"" type:"existingfile" help:"File to use as input JSON data"`
 	// Pretty is a flag to pretty print the JSON output.
-	Pretty bool `arg:"" default:"false" help:"Pretty print the JSON output"`
+	Pretty bool `name:"pretty" default:"false" help:"Pretty print the JSON output"`
 }
 
 func (c *invokeCmd) Run() error {

--- a/pkg/transport/http/router/rest/generated.go
+++ b/pkg/transport/http/router/rest/generated.go
@@ -15,7 +15,7 @@ func RestV1() (string, router.Loader) {
 }
 
 type Documentation struct {
-	SwaggerUI  bool `json:"swaggerUI" yaml:"swaggerUI" msgpack:"swaggerUI" mapstructure:"swaggerUI" validate:"required"`
-	Postman    bool `json:"postman" yaml:"postman" msgpack:"postman" mapstructure:"postman" validate:"required"`
-	RestClient bool `json:"restClient" yaml:"restClient" msgpack:"restClient" mapstructure:"restClient" validate:"required"`
+	SwaggerUI  *bool `json:"swaggerUI,omitempty" yaml:"swaggerUI,omitempty" msgpack:"swaggerUI,omitempty" mapstructure:"swaggerUI"`
+	Postman    *bool `json:"postman,omitempty" yaml:"postman,omitempty" msgpack:"postman,omitempty" mapstructure:"postman"`
+	RestClient *bool `json:"restClient,omitempty" yaml:"restClient,omitempty" msgpack:"restClient,omitempty" mapstructure:"restClient"`
 }

--- a/pkg/transport/http/router/rest/rest.go
+++ b/pkg/transport/http/router/rest/rest.go
@@ -138,7 +138,7 @@ func NewV1(log logr.Logger, tracer trace.Tracer, config RestV1Config, namespaces
 		if strings.HasPrefix(docsHost, ":") {
 			docsHost = "localhost" + docsHost
 		}
-		if config.Documentation.SwaggerUI {
+		if config.Documentation.SwaggerUI != nil && *config.Documentation.SwaggerUI {
 			log.Info("Swagger UI", "url", fmt.Sprintf("http://%s/swagger/", docsHost))
 			log.Info("Swagger Spec", "url", fmt.Sprintf("http://%s/swagger/swagger_spec", docsHost))
 			if err := RegisterSwaggerRoutes(r, namespaces); err != nil {
@@ -146,14 +146,14 @@ func NewV1(log logr.Logger, tracer trace.Tracer, config RestV1Config, namespaces
 			}
 		}
 
-		if config.Documentation.Postman {
+		if config.Documentation.Postman != nil && *config.Documentation.Postman {
 			log.Info("Postman collection", "url", fmt.Sprintf("http://%s/postman/collection", docsHost))
 			if err := RegisterPostmanRoutes(r, namespaces); err != nil {
 				return err
 			}
 		}
 
-		if config.Documentation.RestClient {
+		if config.Documentation.RestClient != nil && *config.Documentation.RestClient {
 			log.Info("VS Code REST Client", "url", fmt.Sprintf("http://%s/rest-client/service.http", docsHost))
 			if err := RegisterRESTClientRoutes(r, namespaces); err != nil {
 				return err

--- a/pkg/transport/http/router/router/generated.go
+++ b/pkg/transport/http/router/router/generated.go
@@ -7,14 +7,16 @@ import (
 	"github.com/nanobus/nanobus/pkg/transport/http/router"
 )
 
-type RouterV1Config []Route
+type RouterV1Config struct {
+	Routes []AddRoute `json:"routes" yaml:"routes" msgpack:"routes" mapstructure:"routes" validate:"required"`
+}
 
 func RouterV1() (string, router.Loader) {
 	return "nanobus.transport.http.router/v1", RouterV1Loader
 }
 
-type Route struct {
-	Methods  string          `json:"methods" yaml:"methods" msgpack:"methods" mapstructure:"methods" validate:"required"`
+type AddRoute struct {
+	Method   string          `json:"method" yaml:"method" msgpack:"method" mapstructure:"method" validate:"required"`
 	URI      string          `json:"uri" yaml:"uri" msgpack:"uri" mapstructure:"uri" validate:"required"`
 	Encoding *string         `json:"encoding,omitempty" yaml:"encoding,omitempty" msgpack:"encoding,omitempty" mapstructure:"encoding"`
 	Handler  handler.Handler `json:"handler" yaml:"handler" msgpack:"handler" mapstructure:"handler" validate:"required"`

--- a/specs/transport/http/router.axdl
+++ b/specs/transport/http/router.axdl
@@ -6,11 +6,14 @@
 
 namespace "nanobus.transport.http"
 
-alias RouterV1Config = [AddRoute] @router("nanobus.transport.http.router/v1")
 alias Handler = string
 
+type RouterV1Config @router("nanobus.transport.http.router/v1") {
+  routes: [AddRoute]
+}
+
 type AddRoute {
-  methods: string
+  method: string
   uri: string
   encoding: string?
   handler: Handler


### PR DESCRIPTION
This PR:
- moves busFile and resourcesFile for `nanobus run` and `nanobus invoke` to options vs positional arguments since they are edge cases and it was strange to have common cases in `nanobus invoke` be options (interface/action) while the edge case were positional.
- moves pretty printing on `nanobus invoke` from a positional argument to a flag
- makes `documentation` configuration in `rest` router (swagger et al) optional
- changed the configuration for `transport.http.router/v1` from an array to a struct with a child property of `routes` that houses the original intended config. The nanobus configuration validation fails any configuration that isn't a struct due to https://github.com/nanobus/nanobus/blob/main/pkg/config/decode.go#L64. It seemed easier to make the config a struct vs figure out the implications of changing the validation there.