### PR TITLE
Updated vscode and prettier config to avoid formatting conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 /dist
 /lib
 *.pem
+<<<<<<< Updated upstream
 go.work.sum
+=======
+/archive
+>>>>>>> Stashed changes

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@
 /dist
 /lib
 *.pem
-<<<<<<< Updated upstream
 go.work.sum
-=======
 /archive
->>>>>>> Stashed changes

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
-    "deno.enable": true,
-    "deno.unstable": true
+  "deno.enable": true,
+  "deno.unstable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
 }


### PR DESCRIPTION
This PR:
- Updates prettierrc to prefer single quotes so default settings do now cause conflicts.
- Sets VS code to use deno's formatter to format TypeScript.
- Adds `/archive` to `.gitignore`