### PR TITLE
Small proposed changes to http server and base router

### DIFF
--- a/pkg/transport/http/generated.go
+++ b/pkg/transport/http/generated.go
@@ -10,7 +10,7 @@ import (
 type HttpServerV1Config struct {
 	Address    string              `json:"address" yaml:"address" msgpack:"address" mapstructure:"address" validate:"required"`
 	Middleware []runtime.Component `json:"middleware,omitempty" yaml:"middleware,omitempty" msgpack:"middleware,omitempty" mapstructure:"middleware"`
-	Routes     []runtime.Component `json:"routes,omitempty" yaml:"routes,omitempty" msgpack:"routes,omitempty" mapstructure:"routes"`
+	Routers    []runtime.Component `json:"routers,omitempty" yaml:"routers,omitempty" msgpack:"routers,omitempty" mapstructure:"routers"`
 }
 
 func HttpServerV1() (string, transport.Loader) {

--- a/pkg/transport/http/router/router/generated.go
+++ b/pkg/transport/http/router/router/generated.go
@@ -19,5 +19,6 @@ type AddRoute struct {
 	Method   string          `json:"method" yaml:"method" msgpack:"method" mapstructure:"method" validate:"required"`
 	URI      string          `json:"uri" yaml:"uri" msgpack:"uri" mapstructure:"uri" validate:"required"`
 	Encoding *string         `json:"encoding,omitempty" yaml:"encoding,omitempty" msgpack:"encoding,omitempty" mapstructure:"encoding"`
+	Raw      *bool           `json:"raw,omitempty" yaml:"raw,omitempty" msgpack:"raw,omitempty" mapstructure:"raw"`
 	Handler  handler.Handler `json:"handler" yaml:"handler" msgpack:"handler" mapstructure:"handler" validate:"required"`
 }

--- a/pkg/transport/http/server.go
+++ b/pkg/transport/http/server.go
@@ -82,8 +82,8 @@ func HttpServerV1Loader(ctx context.Context, with interface{}, resolver resolve.
 		middlewares[i] = middleware
 	}
 
-	routers := make([]router.Router, len(c.Routes))
-	for i, route := range c.Routes {
+	routers := make([]router.Router, len(c.Routers))
+	for i, route := range c.Routers {
 		r := routerRegistry[route.Uses]
 		router, err := r(ctx, route.With, resolver)
 		if err != nil {

--- a/specs/transport/http/router.axdl
+++ b/specs/transport/http/router.axdl
@@ -16,5 +16,6 @@ type AddRoute {
   method: string
   uri: string
   encoding: string?
+  raw: bool?
   handler: Handler
 }

--- a/specs/transport/http/server.axdl
+++ b/specs/transport/http/server.axdl
@@ -11,5 +11,5 @@ alias Component = any
 type HttpServerV1Config @transport("nanobus.transport.http.server/v1") {
   address:    string
   middleware: [Component]?
-  routes:     [Component]?
+  routers:    [Component]?
 }


### PR DESCRIPTION
This PR:
- Changed `routes` to `routers` in HTTP server config.
- Changed default arg behavior in the base router to flatten all input (body, query string, and path args) to more seamlessly line up with simple actions. I added a `raw` option to the route configuration to get the arguments expanded into separate buckets.