### PR TITLE
Added baseUrl to aid file resolution, added subset config for Iotas 

### DIFF
--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -200,7 +200,13 @@ func (c *pushCmd) Run() error {
 	}
 	defer busFile.Close()
 
-	conf, err := runtime.LoadBusYAML(busFile)
+	absPath, err := filepath.Abs(c.BusFile)
+	if err != nil {
+		return err
+	}
+	baseDir := filepath.Dir(absPath)
+
+	conf, err := runtime.LoadBusYAML(baseDir, busFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/compute/wasmrs/wasmrs.go
+++ b/pkg/compute/wasmrs/wasmrs.go
@@ -10,6 +10,7 @@ package wasmrs
 
 import (
 	"context"
+	"net/url"
 	"os"
 
 	"github.com/nanobus/iota/go/transport/wasmrs/host"
@@ -37,7 +38,12 @@ func Loader(ctx context.Context, with interface{}, resolver resolve.ResolveAs) (
 		return nil, err
 	}
 
-	source, err := os.ReadFile(string(c.Filename))
+	targetUrl, err := url.Parse(string(c.Filename))
+	if err != nil {
+		return nil, err
+	}
+
+	source, err := os.ReadFile(targetUrl.Path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -31,12 +31,14 @@ func NormalizeUrl(url string, base ...string) (string, error) {
 	} else {
 		baseUrl = GetBase(nil)
 	}
-	if strings.HasPrefix(url, ".") {
-		normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", path.Join(baseUrl, url)))
-	} else if strings.HasPrefix(url, "/") {
-		normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", url))
-	} else {
-		normalUrl, err = URL.Parse(url)
+	normalUrl, err = URL.Parse(url)
+
+	if err != nil || normalUrl.Scheme == "" {
+		if strings.HasPrefix(url, "/") {
+			normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", url))
+		} else if strings.HasPrefix(url, ".") {
+			normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", path.Join(baseUrl, url)))
+		}
 	}
 	if err != nil {
 		return "", err

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"fmt"
+	URL "net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/PuerkitoBio/purell"
+)
+
+func GetBase(base *string) string {
+	if base == nil || *base == "" {
+		baseUrl, err := os.Getwd()
+		if err != nil {
+			return ""
+		}
+		return baseUrl
+	} else {
+		return *base
+	}
+}
+
+func NormalizeUrl(url string, base ...string) (string, error) {
+	var normalUrl *URL.URL
+	var err error
+	var baseUrl string
+	if len(base) > 0 {
+		baseUrl = GetBase(&base[0])
+	} else {
+		baseUrl = GetBase(nil)
+	}
+	if strings.HasPrefix(url, ".") {
+		normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", path.Join(baseUrl, url)))
+	} else if strings.HasPrefix(url, "/") {
+		normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", url))
+	} else {
+		normalUrl, err = URL.Parse(url)
+	}
+	if err != nil {
+		return "", err
+	}
+	normal := purell.NormalizeURL(normalUrl, purell.FlagsUsuallySafeGreedy|purell.FlagRemoveDuplicateSlashes|purell.FlagRemoveFragment)
+	return normal, err
+}

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var cwd, _ = os.Getwd()
+
+func TestRelativeUrl(t *testing.T) {
+	url, err := NormalizeUrl("./here.txt")
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("file://%s/here.txt", cwd), url)
+}
+
+func TestUglyRelativeUrl(t *testing.T) {
+	url, err := NormalizeUrl("./././foo/..////////here.txt")
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("file://%s/here.txt", cwd), url)
+}
+
+func TestRelativeUrlWithRelativeBase(t *testing.T) {
+	url, err := NormalizeUrl("./here.txt", "./dev/src")
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///dev/src/here.txt", url)
+}
+
+func TestRelativeUrlWithAbsoluteBase(t *testing.T) {
+	url, err := NormalizeUrl("./here.txt", "/dev/src")
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///dev/src/here.txt", url)
+}
+
+func TestAbsoluteUrl(t *testing.T) {
+	url, err := NormalizeUrl("/here.txt", "/dev/src")
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///here.txt", url)
+}
+
+func TestHttpUrl(t *testing.T) {
+	url, err := NormalizeUrl("http://this.com/that.txt", "/dev/src")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://this.com/that.txt", url)
+}
+
+func TestUglyHttpUrl(t *testing.T) {
+	url, err := NormalizeUrl("http://this.com/foo/../foo/../foo////////that.txt", "/dev/src")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://this.com/foo/that.txt", url)
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -568,7 +568,7 @@ func Start(info *Info) error {
 	}
 
 	for name, include := range busConfig.Includes {
-		config, err := runtime.LoadIotaConfig(include.Ref, *busConfig.BaseURL)
+		config, err := runtime.LoadIotaConfig(log, include.Ref, *busConfig.BaseURL)
 		if err != nil {
 			log.Error(err, "Could not read Iota config")
 			return err
@@ -863,13 +863,13 @@ func loadBusConfig(filename string, log logr.Logger) (*runtime.BusConfig, error)
 	}
 	defer f.Close()
 
-	// absPath, err := filepath.Abs(filename)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// baseDir := filepath.Dir(absPath)
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+	baseDir := filepath.Dir(absPath)
 
-	c, err := runtime.LoadBusYAML(f)
+	c, err := runtime.LoadBusYAML(baseDir, f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The NanoBus Authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nanobus/nanobus/pkg/handler"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestInvoke(t *testing.T) {
+	var input any = map[string]interface{}{
+		"name": "World",
+	}
+	handler := handler.Handler{Interface: "Greeter", Operation: "SayHello"}
+	info := Info{
+		Mode:          ModeInvoke,
+		LogLevel:      zapcore.ErrorLevel,
+		BusFile:       "test-data/greeter.yaml",
+		ResourcesFile: "",
+		EntityID:      "nothing",
+		DeveloperMode: false,
+	}
+	engine, err := Start(&info)
+	assert.NoError(t, err)
+	response, err := engine.Invoke(handler, input)
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	response, err = engine.InvokeUnsafe(handler, input)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello, World", response)
+	fmt.Println(response)
+}

--- a/pkg/engine/test-data/greeter.yaml
+++ b/pkg/engine/test-data/greeter.yaml
@@ -1,0 +1,10 @@
+id: your-app
+version: 0.0.1
+interfaces:
+  Greeter:
+    SayHello:
+      steps:
+        - name: Say Hello!
+          uses: assign
+          with:
+            value: '"Hello, " + input.name'

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,28 @@
+package logger
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/mattn/go-colorable"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func GetLogger(logLevel zapcore.Level) logr.Logger {
+	// Initialize logger
+	zapConfig := zap.NewDevelopmentEncoderConfig()
+	zapConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	zapLog := zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zapConfig),
+		zapcore.AddSync(colorable.NewColorableStdout()),
+		logLevel,
+	))
+	//zapLog, err := zapConfig.Build()
+	//zapLog, err := zap.NewProduction()
+	// if err != nil {
+	//      panic(err)
+	// }
+	// zapLog := zap.NewExample()
+	log := zapr.NewLogger(zapLog)
+	return log
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -8,8 +8,32 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func GetLogger(logLevel zapcore.Level) logr.Logger {
-	// Initialize logger
+var sugar zap.SugaredLogger = *initLogger()
+var logger logr.Logger
+
+func Debug(msg string, keysAndValues ...interface{}) {
+	sugar.Debug(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func Info(msg string, keysAndValues ...interface{}) {
+	sugar.Info(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func Warn(msg string, keysAndValues ...interface{}) {
+	sugar.Warn(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func Error(msg string, keysAndValues ...interface{}) {
+	sugar.Error(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func initLogger() *zap.SugaredLogger {
+	zapLog := initZap(zapcore.InfoLevel)
+	logger = zapr.NewLogger(zapLog)
+	return zapLog.Sugar()
+}
+
+func initZap(logLevel zapcore.Level) *zap.Logger {
 	zapConfig := zap.NewDevelopmentEncoderConfig()
 	zapConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	zapLog := zap.New(zapcore.NewCore(
@@ -17,12 +41,15 @@ func GetLogger(logLevel zapcore.Level) logr.Logger {
 		zapcore.AddSync(colorable.NewColorableStdout()),
 		logLevel,
 	))
-	//zapLog, err := zapConfig.Build()
-	//zapLog, err := zap.NewProduction()
-	// if err != nil {
-	//      panic(err)
-	// }
-	// zapLog := zap.NewExample()
-	log := zapr.NewLogger(zapLog)
-	return log
+	return zapLog
+}
+
+func SetLogLevel(logLevel zapcore.Level) {
+	zapLog := initZap(logLevel)
+	sugar = *zapLog.Sugar()
+	logger = zapr.NewLogger(zapLog)
+}
+
+func GetLogger() logr.Logger {
+	return logger
 }

--- a/pkg/runtime/apex.axdl
+++ b/pkg/runtime/apex.axdl
@@ -23,9 +23,9 @@ type ResourcesConfig {
 
 "The main Iota component/application configuration."
 type BusConfig {
-  "The Iota identifier."
+  "The Application identifier."
   id: string
-  "The Iota version."
+  "The Application version."
   version: string
   "The main code binary (wasm or native)."
   main: string?
@@ -65,6 +65,26 @@ type BusConfig {
   "Pipelines that preform data access (typically using resources) on behalf of the application."
   providers: Interfaces?
   errors: { string : ErrorTemplate }?
+  "If set, the base path or URL with which to resolve relative dependencies"
+  baseUrl: string?
+}
+
+"The configuration for an iota."
+type IotaConfig {
+  "The Iota version."
+  version: string
+  "The iota's executable entrypoint."
+  main: string?
+  "The iota's interface definition."
+  spec: string?
+  "Resources are externally configured sources and receivers of data (DB, REST endpoint)."
+  resources: [string]
+  "Interface composed from declarative pipelines."
+  interfaces: Interfaces
+  "Pipelines that preform data access (typically using resources) on behalf of the application."
+  providers: Interfaces
+  "If set, the base path or URL with which to resolve relative dependencies"
+  baseUrl: string?
 }
 
 "Package defines the contents of the OCI image."
@@ -294,7 +314,7 @@ enum ErrCode {
   system is not in a state required for the operation's execution.
   For example, directory to be deleted may be non-empty, an rmdir
   operation is applied to a non-directory, etc.
-  
+
   A litmus test that may help a service implementor in deciding
   between FailedPrecondition, Aborted, and Unavailable:
    (a) Use Unavailable if the client can retry just the failing call.
@@ -316,7 +336,7 @@ enum ErrCode {
   Aborted indicates the operation was aborted, typically due to a
   concurrency issue like sequencer check failures, transaction aborts,
   etc.
-  
+
   See litmus test above for deciding between FailedPrecondition,
   Aborted, and Unavailable.
   """
@@ -325,14 +345,14 @@ enum ErrCode {
   """
   OutOfRange means operation was attempted past the valid range.
   E.g., seeking or reading past end of file.
-  
+
   Unlike InvalidArgument, this error indicates a problem that may
   be fixed if the system state changes. For example, a 32-bit file
   system will generate InvalidArgument if asked to read at an
   offset that is not in the range [0,2^32-1], but it will generate
   OutOfRange if asked to read from an offset past the current
   file size.
-  
+
   There is a fair bit of overlap between FailedPrecondition and
   OutOfRange. We recommend using OutOfRange (the more specific
   error) when it applies so that callers who are iterating through
@@ -359,7 +379,7 @@ enum ErrCode {
   This is a most likely a transient condition and may be corrected
   by retrying with a backoff. Note that it is not always safe to retry
   non-idempotent operations.
-  
+
   See litmus test above for deciding between FailedPrecondition,
   Aborted, and Unavailable.
   """

--- a/pkg/runtime/apex.axdl
+++ b/pkg/runtime/apex.axdl
@@ -35,7 +35,7 @@ type BusConfig {
   package: Package?
   "Resources are externally configured sources and receivers of data (DB, REST endpoint)."
   resources: [string]?
-  "Other Iotas that this Iota depends on using."
+  "Imported Iota dependencies."
   includes: { string : Reference }?
   "Tracing configures an Open Telemetry span exporter."
   tracing: Component?
@@ -77,6 +77,8 @@ type IotaConfig {
   main: string?
   "The iota's interface definition."
   spec: string?
+  "Imported Iota dependencies."
+  includes: { string : Reference }?
   "Resources are externally configured sources and receivers of data (DB, REST endpoint)."
   resources: [string]
   "Interface composed from declarative pipelines."

--- a/pkg/runtime/apex.axdl
+++ b/pkg/runtime/apex.axdl
@@ -36,7 +36,7 @@ type BusConfig {
   "Resources are externally configured sources and receivers of data (DB, REST endpoint)."
   resources: [string]?
   "Imported Iota dependencies."
-  includes: { string : Reference }?
+  imports: { string : Reference }?
   "Tracing configures an Open Telemetry span exporter."
   tracing: Component?
   specs: [Component]?
@@ -78,7 +78,7 @@ type IotaConfig {
   "The iota's interface definition."
   spec: string?
   "Imported Iota dependencies."
-  includes: { string : Reference }?
+  imports: { string : Reference }?
   "Resources are externally configured sources and receivers of data (DB, REST endpoint)."
   resources: [string]
   "Interface composed from declarative pipelines."

--- a/pkg/runtime/configuration.go
+++ b/pkg/runtime/configuration.go
@@ -35,7 +35,7 @@ func LoadResourcesYAML(in io.Reader) (*ResourcesConfig, error) {
 	return &c, nil
 }
 
-func LoadBusYAML(in io.Reader) (*BusConfig, error) {
+func LoadBusYAML(baseDir string, in io.Reader) (*BusConfig, error) {
 	data, err := io.ReadAll(in)
 	if err != nil {
 		return nil, err
@@ -44,6 +44,7 @@ func LoadBusYAML(in io.Reader) (*BusConfig, error) {
 	c := DefaultBusConfig()
 
 	if err := rootConfig.LoadYAML(string(data), &c); err != nil {
+		c.BaseURL = &baseDir
 		return nil, err
 	}
 

--- a/pkg/runtime/configuration.go
+++ b/pkg/runtime/configuration.go
@@ -44,9 +44,9 @@ func LoadBusYAML(baseDir string, in io.Reader) (*BusConfig, error) {
 	c := DefaultBusConfig()
 
 	if err := rootConfig.LoadYAML(string(data), &c); err != nil {
-		c.BaseURL = &baseDir
 		return nil, err
 	}
+	c.BaseURL = &baseDir
 
 	return &c, nil
 }

--- a/pkg/runtime/defaults.go
+++ b/pkg/runtime/defaults.go
@@ -40,6 +40,24 @@ func (h *BusConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// Returns a IotaConfig instance with default fields populated
+
+func DefaultIotaConfig() IotaConfig {
+	obj := IotaConfig{}
+
+	return obj
+}
+
+func (h *IotaConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type alias IotaConfig
+	raw := alias(DefaultIotaConfig())
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	*h = IotaConfig(raw)
+	return nil
+}
+
 // Returns a Package instance with default fields populated
 
 func DefaultPackage() Package {

--- a/pkg/runtime/generated.go
+++ b/pkg/runtime/generated.go
@@ -34,9 +34,9 @@ type ResourcesConfig struct {
 
 // The main Iota component/application configuration.
 type BusConfig struct {
-	// The Iota identifier.
+	// The Application identifier.
 	ID string `json:"id" yaml:"id" msgpack:"id" mapstructure:"id" validate:"required"`
-	// The Iota version.
+	// The Application version.
 	Version string `json:"version" yaml:"version" msgpack:"version" mapstructure:"version" validate:"required"`
 	// The main code binary (wasm or native).
 	Main *string `json:"main,omitempty" yaml:"main,omitempty" msgpack:"main,omitempty" mapstructure:"main"`
@@ -77,6 +77,28 @@ type BusConfig struct {
 	// application.
 	Providers Interfaces               `json:"providers,omitempty" yaml:"providers,omitempty" msgpack:"providers,omitempty" mapstructure:"providers"`
 	Errors    map[string]ErrorTemplate `json:"errors,omitempty" yaml:"errors,omitempty" msgpack:"errors,omitempty" mapstructure:"errors" validate:"dive"`
+	// If set, the base path or URL with which to resolve relative dependencies
+	BaseURL *string `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty" msgpack:"baseUrl,omitempty" mapstructure:"baseUrl"`
+}
+
+// The configuration for an iota.
+type IotaConfig struct {
+	// The Iota version.
+	Version string `json:"version" yaml:"version" msgpack:"version" mapstructure:"version" validate:"required"`
+	// The iota's executable entrypoint.
+	Main *string `json:"main,omitempty" yaml:"main,omitempty" msgpack:"main,omitempty" mapstructure:"main"`
+	// The iota's interface definition.
+	Spec *string `json:"spec,omitempty" yaml:"spec,omitempty" msgpack:"spec,omitempty" mapstructure:"spec"`
+	// Resources are externally configured sources and receivers of data (DB, REST
+	// endpoint).
+	Resources []string `json:"resources" yaml:"resources" msgpack:"resources" mapstructure:"resources" validate:"required"`
+	// Interface composed from declarative pipelines.
+	Interfaces Interfaces `json:"interfaces" yaml:"interfaces" msgpack:"interfaces" mapstructure:"interfaces" validate:"required"`
+	// Pipelines that preform data access (typically using resources) on behalf of the
+	// application.
+	Providers Interfaces `json:"providers" yaml:"providers" msgpack:"providers" mapstructure:"providers" validate:"required"`
+	// If set, the base path or URL with which to resolve relative dependencies
+	BaseURL *string `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty" msgpack:"baseUrl,omitempty" mapstructure:"baseUrl"`
 }
 
 // Package defines the contents of the OCI image.

--- a/pkg/runtime/generated.go
+++ b/pkg/runtime/generated.go
@@ -48,7 +48,7 @@ type BusConfig struct {
 	// endpoint).
 	Resources []string `json:"resources,omitempty" yaml:"resources,omitempty" msgpack:"resources,omitempty" mapstructure:"resources" validate:"dive"`
 	// Imported Iota dependencies.
-	Includes map[string]Reference `json:"includes,omitempty" yaml:"includes,omitempty" msgpack:"includes,omitempty" mapstructure:"includes" validate:"dive"`
+	Imports map[string]Reference `json:"imports,omitempty" yaml:"imports,omitempty" msgpack:"imports,omitempty" mapstructure:"imports" validate:"dive"`
 	// Tracing configures an Open Telemetry span exporter.
 	Tracing *Component  `json:"tracing,omitempty" yaml:"tracing,omitempty" msgpack:"tracing,omitempty" mapstructure:"tracing"`
 	Specs   []Component `json:"specs,omitempty" yaml:"specs,omitempty" msgpack:"specs,omitempty" mapstructure:"specs" validate:"dive"`
@@ -90,7 +90,7 @@ type IotaConfig struct {
 	// The iota's interface definition.
 	Spec *string `json:"spec,omitempty" yaml:"spec,omitempty" msgpack:"spec,omitempty" mapstructure:"spec"`
 	// Imported Iota dependencies.
-	Includes map[string]Reference `json:"includes,omitempty" yaml:"includes,omitempty" msgpack:"includes,omitempty" mapstructure:"includes" validate:"dive"`
+	Imports map[string]Reference `json:"imports,omitempty" yaml:"imports,omitempty" msgpack:"imports,omitempty" mapstructure:"imports" validate:"dive"`
 	// Resources are externally configured sources and receivers of data (DB, REST
 	// endpoint).
 	Resources []string `json:"resources" yaml:"resources" msgpack:"resources" mapstructure:"resources" validate:"dive"`

--- a/pkg/runtime/generated.go
+++ b/pkg/runtime/generated.go
@@ -47,7 +47,7 @@ type BusConfig struct {
 	// Resources are externally configured sources and receivers of data (DB, REST
 	// endpoint).
 	Resources []string `json:"resources,omitempty" yaml:"resources,omitempty" msgpack:"resources,omitempty" mapstructure:"resources" validate:"dive"`
-	// Other Iotas that this Iota depends on using.
+	// Imported Iota dependencies.
 	Includes map[string]Reference `json:"includes,omitempty" yaml:"includes,omitempty" msgpack:"includes,omitempty" mapstructure:"includes" validate:"dive"`
 	// Tracing configures an Open Telemetry span exporter.
 	Tracing *Component  `json:"tracing,omitempty" yaml:"tracing,omitempty" msgpack:"tracing,omitempty" mapstructure:"tracing"`
@@ -89,14 +89,16 @@ type IotaConfig struct {
 	Main *string `json:"main,omitempty" yaml:"main,omitempty" msgpack:"main,omitempty" mapstructure:"main"`
 	// The iota's interface definition.
 	Spec *string `json:"spec,omitempty" yaml:"spec,omitempty" msgpack:"spec,omitempty" mapstructure:"spec"`
+	// Imported Iota dependencies.
+	Includes map[string]Reference `json:"includes,omitempty" yaml:"includes,omitempty" msgpack:"includes,omitempty" mapstructure:"includes" validate:"dive"`
 	// Resources are externally configured sources and receivers of data (DB, REST
 	// endpoint).
-	Resources []string `json:"resources" yaml:"resources" msgpack:"resources" mapstructure:"resources" validate:"required"`
+	Resources []string `json:"resources" yaml:"resources" msgpack:"resources" mapstructure:"resources" validate:"dive"`
 	// Interface composed from declarative pipelines.
-	Interfaces Interfaces `json:"interfaces" yaml:"interfaces" msgpack:"interfaces" mapstructure:"interfaces" validate:"required"`
+	Interfaces Interfaces `json:"interfaces" yaml:"interfaces" msgpack:"interfaces" mapstructure:"interfaces"`
 	// Pipelines that preform data access (typically using resources) on behalf of the
 	// application.
-	Providers Interfaces `json:"providers" yaml:"providers" msgpack:"providers" mapstructure:"providers" validate:"required"`
+	Providers Interfaces `json:"providers" yaml:"providers" msgpack:"providers" mapstructure:"providers"`
 	// If set, the base path or URL with which to resolve relative dependencies
 	BaseURL *string `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty" msgpack:"baseUrl,omitempty" mapstructure:"baseUrl"`
 }

--- a/pkg/runtime/iota.go
+++ b/pkg/runtime/iota.go
@@ -14,9 +14,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
 	"github.com/nanobus/nanobus/pkg/config"
-	"github.com/nanobus/nanobus/pkg/logger"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/nanobus/nanobus/pkg/oci"
 )
@@ -37,9 +36,8 @@ func ToContext(ctx context.Context, function IotaConfig) context.Context {
 	return context.WithValue(ctx, iotaKey{}, function)
 }
 
-func LoadIotaConfig(url string, baseUrl string) (IotaConfig, error) {
+func LoadIotaConfig(log logr.Logger, url string, baseUrl string) (IotaConfig, error) {
 	h := IotaConfig{}
-	log := logger.GetLogger(zapcore.DebugLevel)
 	log.Info("Importing configuration from", "location", url)
 
 	var busFile string

--- a/pkg/runtime/iota.go
+++ b/pkg/runtime/iota.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 The NanoBus Authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/nanobus/nanobus/pkg/config"
+	"github.com/nanobus/nanobus/pkg/logger"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/nanobus/nanobus/pkg/oci"
+)
+
+type iotaKey struct{}
+
+func FromContext(ctx context.Context) IotaConfig {
+	v := ctx.Value(iotaKey{})
+	if v == nil {
+		return IotaConfig{}
+	}
+	c, _ := v.(IotaConfig)
+
+	return c
+}
+
+func ToContext(ctx context.Context, function IotaConfig) context.Context {
+	return context.WithValue(ctx, iotaKey{}, function)
+}
+
+func LoadIotaConfig(url string, baseUrl string) (IotaConfig, error) {
+	h := IotaConfig{}
+	log := logger.GetLogger(zapcore.DebugLevel)
+	log.Info("Importing configuration from", "location", url)
+
+	var busFile string
+	ref := url
+
+	if oci.IsImageReference(ref) {
+		return h, errors.New("references not currently supported")
+	}
+
+	path := filepath.Join(baseUrl, ref)
+	info, err := os.Stat(path)
+	if err != nil {
+		return h, err
+	}
+
+	configBaseUrl := path
+	if info.IsDir() {
+		busFile = filepath.Join(path, "iota.yaml")
+		log.Info("Using configuration at", "location", busFile)
+	} else {
+		busFile = path
+		configBaseUrl = filepath.Dir(path)
+	}
+
+	err = config.LoadYamlFile(busFile, &h)
+	if err != nil {
+		return h, err
+	}
+
+	h.BaseURL = &configBaseUrl
+	return h, nil
+}

--- a/pkg/spec/apex/apex.go
+++ b/pkg/spec/apex/apex.go
@@ -10,6 +10,7 @@ package apex
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"strings"
 
@@ -42,7 +43,12 @@ func Loader(ctx context.Context, with interface{}, resolveAs resolve.ResolveAs) 
 		return nil, err
 	}
 
-	specBytes, err := os.ReadFile(string(c.Filename))
+	targetUrl, err := url.Parse(string(c.Filename))
+	if err != nil {
+		return nil, err
+	}
+	specBytes, err := os.ReadFile(targetUrl.Path)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/http/server.go
+++ b/pkg/transport/http/server.go
@@ -10,6 +10,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 
@@ -75,6 +76,9 @@ func HttpServerV1Loader(ctx context.Context, with interface{}, resolver resolve.
 	middlewares := make([]middleware.Middleware, len(c.Middleware))
 	for i, component := range c.Middleware {
 		m := middlewareRegistry[component.Uses]
+		if m == nil {
+			return nil, errors.New("could not find middleware: " + component.Uses)
+		}
 		middleware, err := m(ctx, component.With, resolver)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR:
- Removes instances of changing the working directory in favor of tracking the baseUrl per imported configuration
- Adds a subset configuration for included Iotas to differentiate them from root applications that have features like transports etc.