### PR TITLE
Fix lint errors from golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint project
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19.4'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 3m0s

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -17,7 +17,6 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/nanobus/nanobus/pkg/engine"
@@ -176,7 +175,7 @@ func (c *invokeCmd) Run() error {
 	var result any
 	result, err = e.InvokeUnsafe(h, input)
 	if err != nil {
-		logger.Error("error invoking operation", zap.Error(err))
+		logger.Error("error invoking operation", "error", err)
 		return nil
 	}
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,12 @@ deps:
 	go get -u golang.org/x/tools/cmd/goimports
 
 test:
+  #!/usr/bin/env bash
+  FILES=$(gofmt -l .); if [[ "$FILES" == "" ]]; then echo 'Formatting is OK'; else echo "The following files need to be formatting: \n$FILES"; exit 1; fi
   go test ./pkg/...
+
+format:
+  go fmt ./pkg/... ./cmd/...
 
 build:
 	CGO_ENABLED=0 go build -o {{BUILDDIR}}/{{BINARY}} {{MAIN}}

--- a/pkg/actions/core/invoke.go
+++ b/pkg/actions/core/invoke.go
@@ -99,10 +99,3 @@ func InvokeAction(
 		return nil, nil
 	}
 }
-
-func orEmpty(value *string) string {
-	if value != nil {
-		return *value
-	}
-	return ""
-}

--- a/pkg/actions/gorm/utils.go
+++ b/pkg/actions/gorm/utils.go
@@ -9,12 +9,8 @@
 package gorm
 
 import (
-	"context"
 	"fmt"
 	"reflect"
-	"strings"
-
-	"github.com/jackc/pgx/v4/pgxpool"
 
 	"github.com/nanobus/nanobus/pkg/spec"
 )
@@ -34,80 +30,82 @@ func reflectType(t *spec.TypeRef) reflect.Type {
 	return nil
 }
 
-func getOne(ctx context.Context, conn *pgxpool.Conn, config *FindConfig, t *spec.Type, idColumn string, idValue interface{}, toPreload []Preload) (interface{}, error) {
-	keyCol := keyColumn(t)
-	sql := generateTableSQL(t)
-	rows, err := conn.Query(ctx, sql+" WHERE "+idColumn+"=$1", idValue)
-	if err != nil {
-		return nil, err
-	}
+// TODO(jsoverson): Eventually delete or use. This is currently unused
+// but may be an artifact of WIP.
+// func getOne(ctx context.Context, conn *pgxpool.Conn, config *FindConfig, t *spec.Type, idColumn string, idValue interface{}, toPreload []Preload) (interface{}, error) {
+// 	keyCol := keyColumn(t)
+// 	sql := generateTableSQL(t)
+// 	rows, err := conn.Query(ctx, sql+" WHERE "+idColumn+"=$1", idValue)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	if rows.Next() {
-		record := make(map[string]interface{})
-		values, err := rows.Values()
-		rows.Close()
-		if err != nil {
-			return nil, err
-		}
-		for i, v := range values {
-			record[t.Fields[i].Name] = v
-		}
+// 	if rows.Next() {
+// 		record := make(map[string]interface{})
+// 		values, err := rows.Values()
+// 		rows.Close()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		for i, v := range values {
+// 			record[t.Fields[i].Name] = v
+// 		}
 
-		for _, preload := range toPreload {
-			ex, ok := t.Field(preload.Field)
-			if !ok {
-				return nil, fmt.Errorf("%s is not a field of %s", preload.Field, t.Name)
-			}
-			fk := annotationValue(ex, "hasOne", "key", "")
-			if fk == "" {
-				return nil, fmt.Errorf("hasOne is not specified on %s", ex.Name)
-			}
+// 		for _, preload := range toPreload {
+// 			ex, ok := t.Field(preload.Field)
+// 			if !ok {
+// 				return nil, fmt.Errorf("%s is not a field of %s", preload.Field, t.Name)
+// 			}
+// 			fk := annotationValue(ex, "hasOne", "key", "")
+// 			if fk == "" {
+// 				return nil, fmt.Errorf("hasOne is not specified on %s", ex.Name)
+// 			}
 
-			res, err := getOne(ctx, conn, config, ex.Type.Type, fk, record[keyCol], preload.Preload)
-			if err != nil {
-				return nil, err
-			}
+// 			res, err := getOne(ctx, conn, config, ex.Type.Type, fk, record[keyCol], preload.Preload)
+// 			if err != nil {
+// 				return nil, err
+// 			}
 
-			record[preload.Field] = res
-		}
+// 			record[preload.Field] = res
+// 		}
 
-		return record, nil
-	}
+// 		return record, nil
+// 	}
 
-	rows.Close()
+// 	rows.Close()
 
-	return nil, nil
-}
+// 	return nil, nil
+// }
 
-func keyColumn(t *spec.Type) string {
-	for _, f := range t.Fields {
-		if _, ok := f.Annotation("key"); ok {
-			return annotationValue(t, "column", "name", f.Name)
-		}
-	}
-	return ""
-}
+// func keyColumn(t *spec.Type) string {
+// 	for _, f := range t.Fields {
+// 		if _, ok := f.Annotation("key"); ok {
+// 			return annotationValue(t, "column", "name", f.Name)
+// 		}
+// 	}
+// 	return ""
+// }
 
-func generateTableSQL(t *spec.Type) string {
-	var buf strings.Builder
+// func generateTableSQL(t *spec.Type) string {
+// 	var buf strings.Builder
 
-	buf.WriteString("SELECT ")
-	for i, f := range t.Fields {
-		column := annotationValue(f, "column", "name", "")
-		if column == "" {
-			continue
-		}
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		buf.WriteString(column)
-	}
-	buf.WriteString(" FROM ")
-	table := annotationValue(t, "entity", "table", t.Name)
-	buf.WriteString(table)
+// 	buf.WriteString("SELECT ")
+// 	for i, f := range t.Fields {
+// 		column := annotationValue(f, "column", "name", "")
+// 		if column == "" {
+// 			continue
+// 		}
+// 		if i > 0 {
+// 			buf.WriteString(", ")
+// 		}
+// 		buf.WriteString(column)
+// 	}
+// 	buf.WriteString(" FROM ")
+// 	table := annotationValue(t, "entity", "table", t.Name)
+// 	buf.WriteString(table)
 
-	return buf.String()
-}
+// 	return buf.String()
+// }
 
 func annotationValue(a spec.Annotator, annotation, argument, defaultValue string) string {
 	if av, ok := a.Annotation(annotation); ok {

--- a/pkg/actions/postgres/utils.go
+++ b/pkg/actions/postgres/utils.go
@@ -20,7 +20,6 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4/pgxpool"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/spec"
@@ -447,7 +446,7 @@ func normalizeValue(v interface{}) interface{} {
 	case pgtype.Numeric:
 		var f float64
 		if err := vv.AssignTo(&f); err != nil {
-			logger.Error("postgres: failed to assign numeric to float64", zap.Error(err))
+			logger.Error("postgres: failed to assign numeric to float64", "error", err)
 		}
 		v = f
 	case pgtype.UUID:

--- a/pkg/actions/postgres/utils.go
+++ b/pkg/actions/postgres/utils.go
@@ -20,7 +20,9 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4/pgxpool"
+	"go.uber.org/zap"
 
+	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/spec"
 )
 
@@ -444,7 +446,9 @@ func normalizeValue(v interface{}) interface{} {
 		v = vv.Int64()
 	case pgtype.Numeric:
 		var f float64
-		vv.AssignTo(&f)
+		if err := vv.AssignTo(&f); err != nil {
+			logger.Error("postgres: failed to assign numeric to float64", zap.Error(err))
+		}
 		v = f
 	case pgtype.UUID:
 		v = uuid.UUID(vv.Bytes).String()

--- a/pkg/channel/metadata/metadata.go
+++ b/pkg/channel/metadata/metadata.go
@@ -21,10 +21,11 @@ type MD map[string][]string
 // New creates an MD from a given key-value map.
 //
 // Only the following ASCII characters are allowed in keys:
-//  - digits: 0-9
-//  - uppercase letters: A-Z (normalized to lower)
-//  - lowercase letters: a-z
-//  - special characters: -_.
+//   - digits: 0-9
+//   - uppercase letters: A-Z (normalized to lower)
+//   - lowercase letters: a-z
+//   - special characters: -_.
+//
 // Uppercase letters are automatically converted to lowercase.
 func New(m map[string]string) MD {
 	md := MD{}
@@ -39,10 +40,11 @@ func New(m map[string]string) MD {
 // Pairs panics if len(kv) is odd.
 //
 // Only the following ASCII characters are allowed in keys:
-//  - digits: 0-9
-//  - uppercase letters: A-Z (normalized to lower)
-//  - lowercase letters: a-z
-//  - special characters: -_.
+//   - digits: 0-9
+//   - uppercase letters: A-Z (normalized to lower)
+//   - lowercase letters: a-z
+//   - special characters: -_.
+//
 // Uppercase letters are automatically converted to lowercase.
 func Pairs(kv ...string) MD {
 	if len(kv)%2 == 1 {

--- a/pkg/channel/transports/mux/mux.go
+++ b/pkg/channel/transports/mux/mux.go
@@ -101,7 +101,10 @@ func wrap(handler functions.Handler) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(response)
+		if _, err := w.Write(response); err != nil {
+			handleError(err, w, http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -122,7 +125,10 @@ func wrapMethod(handler functions.StatefulHandler) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(response)
+		if _, err := w.Write(response); err != nil {
+			handleError(err, w, http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/pkg/channel/transports/wapc/wapc.go
+++ b/pkg/channel/transports/wapc/wapc.go
@@ -15,6 +15,7 @@ import (
 	wapc "github.com/wapc/wapc-go"
 
 	functions "github.com/nanobus/nanobus/pkg/channel"
+	"github.com/nanobus/nanobus/pkg/logger"
 )
 
 const DefaultPoolSize = 0
@@ -49,7 +50,12 @@ func (w *WaPC) Invoke(ctx context.Context, receiver functions.Receiver, payload 
 	if err != nil {
 		return nil, err
 	}
-	defer w.pool.Return(instance)
+	defer func() {
+		err := w.pool.Return(instance)
+		if err != nil {
+			logger.Error("could not return WebAssembly module back to the pool", "err", err)
+		}
+	}()
 
 	return instance.Invoke(ctx, receiver.Namespace+"/"+receiver.Operation, payload)
 }

--- a/pkg/codec/confluentavro/schemaregistry_test.go
+++ b/pkg/codec/confluentavro/schemaregistry_test.go
@@ -11,7 +11,7 @@ package confluentavro_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -46,7 +46,7 @@ func dummyHttpHandler(t *testing.T, method, path string, status int, reqBody, re
 		if reqBody != nil {
 			expbs, err := json.Marshal(reqBody)
 			require.NoError(t, err)
-			bs, err := ioutil.ReadAll(req.Body)
+			bs, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
 			mustEqual(t, strings.Trim(string(bs), "\r\n"), strings.Trim(string(expbs), "\r\n"))
 		}
@@ -55,7 +55,7 @@ func dummyHttpHandler(t *testing.T, method, path string, status int, reqBody, re
 		if respBody != nil {
 			bs, err := json.Marshal(respBody)
 			require.NoError(t, err)
-			resp.Body = ioutil.NopCloser(bytes.NewReader(bs))
+			resp.Body = io.NopCloser(bytes.NewReader(bs))
 		}
 		return &resp, nil
 	})

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/joho/godotenv"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/oklog/run"
@@ -247,7 +246,7 @@ func Start(info *Info) (*Engine, error) {
 
 	// If there is a `.env` file, load its environment variables.
 	if err := godotenv.Load(); err != nil {
-		logger.Debug("could not load dotenv file", zap.Error(err))
+		logger.Debug("could not load dotenv file", "error", err)
 	}
 
 	logger.SetLogLevel(info.LogLevel)
@@ -775,7 +774,7 @@ func Start(info *Info) (*Engine, error) {
 				// TODO: send term sig instead
 				if cmd.Process != nil {
 					if err := cmd.Process.Kill(); err != nil {
-						logger.Error("Error killing process", zap.Error(err))
+						logger.Error("Error killing process", "error", err)
 					}
 				}
 			})

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nanobus/nanobus/pkg/logger"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.uber.org/zap"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
@@ -112,7 +114,9 @@ func pushArtifact(dst *remote.Repository, pack packFunc, packOpts *oras.PackOpti
 	if err := PrintStatus(root, "Fallback ", verbose); err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	dst.SetReferrersCapability(false)
+	if err := dst.SetReferrersCapability(false); err != nil {
+		logger.Warn("failed to disable referrers capability, falling back to defaults", zap.Error(err))
+	}
 	packOpts.PackImageManifest = true
 	root, err = pack()
 	if err != nil {

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/nanobus/nanobus/pkg/logger"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"go.uber.org/zap"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
@@ -115,7 +114,7 @@ func pushArtifact(dst *remote.Repository, pack packFunc, packOpts *oras.PackOpti
 		return ocispec.Descriptor{}, err
 	}
 	if err := dst.SetReferrersCapability(false); err != nil {
-		logger.Warn("failed to disable referrers capability, falling back to defaults", zap.Error(err))
+		logger.Warn("failed to disable referrers capability, falling back to defaults", "error", err)
 	}
 	packOpts.PackImageManifest = true
 	root, err = pack()

--- a/pkg/resiliency/breaker/circuitbreaker_test.go
+++ b/pkg/resiliency/breaker/circuitbreaker_test.go
@@ -33,9 +33,10 @@ func TestCircuitBreaker(t *testing.T) {
 	log := logr.Discard()
 	cb.Initialize(log)
 	for i := 0; i < 3; i++ {
-		cb.Execute(func() error {
+		err := cb.Execute(func() error {
 			return errors.New("test")
 		})
+		assert.Error(t, err)
 	}
 	err = cb.Execute(func() error {
 		return nil

--- a/pkg/resiliency/policy_test.go
+++ b/pkg/resiliency/policy_test.go
@@ -53,7 +53,8 @@ func TestPolicy(t *testing.T) {
 				return nil
 			}
 			policy := resiliency.Policy(logr.Discard(), name, tt.t, tt.r, tt.cb)
-			policy(ctx, fn)
+			err := policy(ctx, fn)
+			assert.NoError(t, err)
 			assert.True(t, called)
 		})
 	}

--- a/pkg/runtime/invoker.go
+++ b/pkg/runtime/invoker.go
@@ -19,7 +19,6 @@ import (
 	"github.com/nanobus/iota/go/payload"
 	"github.com/nanobus/iota/go/rx/flux"
 	"github.com/nanobus/iota/go/rx/mono"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/actions"
 	"github.com/nanobus/nanobus/pkg/channel"
@@ -109,7 +108,7 @@ func (i *Invoker) FireAndForget(ctx context.Context, p payload.Payload) {
 	r, data := i.lookup(ctx, p)
 	go func() {
 		if _, err := r(ctx, data); err != nil {
-			logger.Error("error with FireAndForget request", zap.Error(err))
+			logger.Error("error with FireAndForget request", "error", err)
 		}
 	}()
 }
@@ -194,7 +193,7 @@ func (i *Invoker) lookup(ctx context.Context, p payload.Payload) (Runnable, acti
 	t := i.targets[index]
 	var input interface{}
 	if err := i.codec.Decode(p.Data(), &input); err != nil {
-		logger.Warn("received error when decoding payload", zap.Error(err))
+		logger.Warn("received error when decoding payload", "error", err)
 	}
 	c := claims.FromContext(ctx)
 	data := actions.Data{

--- a/pkg/spec/apex/apex.go
+++ b/pkg/spec/apex/apex.go
@@ -176,7 +176,6 @@ func (p *nsParser) convertFields(fields []*ast.FieldDefinition) []*spec.Field {
 			p.convertTypeRef(field.Type),
 			dv).
 			AddAnnotations(p.convertAnnotations(field.Annotations)...)
-		o[i].InitValidations()
 	}
 
 	return o
@@ -291,7 +290,6 @@ func (p *nsParser) convertParameters(parameters []*ast.ParameterDefinition) []*s
 			p.convertTypeRef(parameter.Type),
 			dv).
 			AddAnnotations(p.convertAnnotations(parameter.Annotations)...)
-		o[i].InitValidations()
 	}
 
 	return o

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -464,9 +464,6 @@ func (t *Type) InitValidations() (*Type, error) {
 	return t, nil
 }
 
-func (f *Field) InitValidations() error {
-	return nil
-}
 
 func NewEnum(name string, description string) *Enum {
 	return &Enum{

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -464,7 +464,6 @@ func (t *Type) InitValidations() (*Type, error) {
 	return t, nil
 }
 
-
 func NewEnum(name string, description string) *Enum {
 	return &Enum{
 		Name:         name,

--- a/pkg/spec/validators.go
+++ b/pkg/spec/validators.go
@@ -9,13 +9,10 @@
 package spec
 
 import (
-	"fmt"
-
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
-	"github.com/spf13/cast"
 )
 
 var (
@@ -42,42 +39,44 @@ func init() {
 	}
 }
 
-var validators = map[string]ValidationLoader{
-	"url": func(t *TypeRef, f *Field, a *Annotation) (Validation, error) {
-		return func(v interface{}) ([]ValidationError, error) {
-			val := validator.New()
-			value := cast.ToString(v)
+// TODO(jsoverson): Eventually delete or use. This is currently unused
+// but I'm keeping it to prevent reimplementation.
+// var validators = map[string]ValidationLoader{
+// 	"url": func(t *TypeRef, f *Field, a *Annotation) (Validation, error) {
+// 		return func(v interface{}) ([]ValidationError, error) {
+// 			val := validator.New()
+// 			value := cast.ToString(v)
 
-			if err := val.Var(value, "url"); err != nil {
-				return []ValidationError{
-					{
-						//Fields:  []string{f.Name},
-						Message: fmt.Sprintf("%q is an invalid URL", f.Name),
-					},
-				}, nil
-			}
+// 			if err := val.Var(value, "url"); err != nil {
+// 				return []ValidationError{
+// 					{
+// 						//Fields:  []string{f.Name},
+// 						Message: fmt.Sprintf("%q is an invalid URL", f.Name),
+// 					},
+// 				}, nil
+// 			}
 
-			return nil, nil
-		}, nil
-	},
-	"email": func(t *TypeRef, f *Field, a *Annotation) (Validation, error) {
-		return func(v interface{}) ([]ValidationError, error) {
-			val := validator.New()
-			value := cast.ToString(v)
+// 			return nil, nil
+// 		}, nil
+// 	},
+// 	"email": func(t *TypeRef, f *Field, a *Annotation) (Validation, error) {
+// 		return func(v interface{}) ([]ValidationError, error) {
+// 			val := validator.New()
+// 			value := cast.ToString(v)
 
-			if err := val.Var(value, "email"); err != nil {
-				return []ValidationError{
-					{
-						//Fields:  []string{f.Name},
-						Message: fmt.Sprintf("%q is an invalid E-Mail address", f.Name),
-					},
-				}, nil
-			}
+// 			if err := val.Var(value, "email"); err != nil {
+// 				return []ValidationError{
+// 					{
+// 						//Fields:  []string{f.Name},
+// 						Message: fmt.Sprintf("%q is an invalid E-Mail address", f.Name),
+// 					},
+// 				}, nil
+// 			}
 
-			return nil, nil
-		}, nil
-	},
-}
+// 			return nil, nil
+// 		}, nil
+// 	},
+// }
 
 var validationRules = map[string]func(a *Annotation) (string, error){
 	"url":   func(a *Annotation) (string, error) { return "url", nil },

--- a/pkg/transport/http/router/oauth2/oauth2.go
+++ b/pkg/transport/http/router/oauth2/oauth2.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
 	"github.com/nanobus/nanobus/pkg/actions"
@@ -188,7 +187,7 @@ func (o *Auth) callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := setSessionCookie(w, token, claims); err != nil {
-		logger.Error("Could not set session cookie", zap.Error(err))
+		logger.Error("Could not set session cookie", "error", err)
 	}
 	http.Redirect(w, r, o.redirectURL, http.StatusTemporaryRedirect)
 }
@@ -255,7 +254,7 @@ func generateStateOauthCookie(w http.ResponseWriter) string {
 
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		logger.Error("error generating randomness for oauth state", zap.Error(err))
+		logger.Error("error generating randomness for oauth state", "error", err)
 	}
 	state := base64.URLEncoding.EncodeToString(b)
 	cookie := http.Cookie{Name: "oauthstate", Value: state, Expires: expiration}

--- a/pkg/transport/http/router/rest/openapi3.go
+++ b/pkg/transport/http/router/rest/openapi3.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
 	"github.com/nanobus/nanobus/pkg/logger"
@@ -64,7 +63,7 @@ func swaggerSpecHandler(b []byte) http.HandlerFunc {
 		swagger := bytes.Replace(b, []byte("[REPLACE_HOST]"), []byte(v), 1)
 
 		if _, err := w.Write(swagger); err != nil {
-			logger.Error("could not write swagger bytes", zap.Error(err))
+			logger.Error("could not write swagger bytes", "error", err)
 			return
 		}
 	}
@@ -257,7 +256,7 @@ func SpecToOpenAPI3(namespaces spec.Namespaces) ([]byte, error) {
 
 	var specData interface{}
 	if err := json.Unmarshal(specBytes, &specData); err != nil {
-		logger.Warn("failed to decode spec bytes", zap.Error(err))
+		logger.Warn("failed to decode spec bytes", "error", err)
 	}
 	specBytesIndented, _ := yaml.Marshal(specData)
 

--- a/pkg/transport/http/router/rest/postman.go
+++ b/pkg/transport/http/router/rest/postman.go
@@ -19,7 +19,9 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gorilla/mux"
 	postman "github.com/rbretecher/go-postman-collection"
+	"go.uber.org/zap"
 
+	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/spec"
 )
 
@@ -36,7 +38,9 @@ func RegisterPostmanRoutes(r *mux.Router, namespaces spec.Namespaces) error {
 			v = "http://" + req.Host
 		}
 		replaced := bytes.Replace(specData, []byte("[REPLACE_HOST]"), []byte(v), 1)
-		w.Write(replaced)
+		if _, err := w.Write(replaced); err != nil {
+			logger.Error("error writing postman response", zap.Error(err))
+		}
 	})
 
 	return nil

--- a/pkg/transport/http/router/rest/postman.go
+++ b/pkg/transport/http/router/rest/postman.go
@@ -19,7 +19,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gorilla/mux"
 	postman "github.com/rbretecher/go-postman-collection"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/spec"
@@ -39,7 +38,7 @@ func RegisterPostmanRoutes(r *mux.Router, namespaces spec.Namespaces) error {
 		}
 		replaced := bytes.Replace(specData, []byte("[REPLACE_HOST]"), []byte(v), 1)
 		if _, err := w.Write(replaced); err != nil {
-			logger.Error("error writing postman response", zap.Error(err))
+			logger.Error("error writing postman response", "error", err)
 		}
 	})
 

--- a/pkg/transport/http/router/rest/rest.go
+++ b/pkg/transport/http/router/rest/rest.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/channel"
 	"github.com/nanobus/nanobus/pkg/config"
@@ -497,7 +496,7 @@ func (t *Rest) handleError(err error, codec channel.Codec, req *http.Request, w 
 	}
 
 	if _, err := w.Write(payload); err != nil {
-		logger.Error("error writing error response", zap.Error(err))
+		logger.Error("error writing error response", "error", err)
 	}
 }
 

--- a/pkg/transport/http/router/rest/restclient.go
+++ b/pkg/transport/http/router/rest/restclient.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/spec"
@@ -36,7 +35,7 @@ func RegisterRESTClientRoutes(r *mux.Router, namespaces spec.Namespaces) error {
 		replaced := bytes.Replace(specData, []byte("[REPLACE_HOST]"), []byte(v), 1)
 
 		if _, err := w.Write(replaced); err != nil {
-			logger.Error("error writing restclient response", zap.Error(err))
+			logger.Error("error writing restclient response", "error", err)
 		}
 
 	})

--- a/pkg/transport/http/router/rest/restclient.go
+++ b/pkg/transport/http/router/rest/restclient.go
@@ -15,7 +15,9 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"go.uber.org/zap"
 
+	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/spec"
 )
 
@@ -32,7 +34,11 @@ func RegisterRESTClientRoutes(r *mux.Router, namespaces spec.Namespaces) error {
 			v = "http://" + req.Host
 		}
 		replaced := bytes.Replace(specData, []byte("[REPLACE_HOST]"), []byte(v), 1)
-		w.Write(replaced)
+
+		if _, err := w.Write(replaced); err != nil {
+			logger.Error("error writing restclient response", zap.Error(err))
+		}
+
 	})
 
 	return nil

--- a/pkg/transport/http/router/router/router.go
+++ b/pkg/transport/http/router/router/router.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/channel"
 	"github.com/nanobus/nanobus/pkg/config"
@@ -226,7 +225,7 @@ func (t *Router) handler(h handler.Handler, raw bool, desiredCodec channel.Codec
 				return
 			}
 			if _, err := w.Write(responseBytes); err != nil {
-				logger.Error("error writing response", zap.Error(err))
+				logger.Error("error writing response", "error", err)
 			}
 		} else {
 			w.WriteHeader(http.StatusNoContent)
@@ -249,7 +248,7 @@ func (t *Router) handleError(err error, codec channel.Codec, req *http.Request, 
 	}
 
 	if _, err := w.Write(payload); err != nil {
-		logger.Error("error writing error response", zap.Error(err))
+		logger.Error("error writing error response", "error", err)
 	}
 }
 

--- a/pkg/transport/http/router/static/static.go
+++ b/pkg/transport/http/router/static/static.go
@@ -133,7 +133,10 @@ func (s *ServerFile) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(code)
 
 	if r.Method != "HEAD" {
-		io.CopyN(w, f, size)
+		if _, err := io.CopyN(w, f, size); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/pkg/transport/httprpc/httprpc.go
+++ b/pkg/transport/httprpc/httprpc.go
@@ -214,7 +214,7 @@ func (t *HTTPRPC) handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, error :=w.Write(responseBytes); error != nil {
+	if _, error := w.Write(responseBytes); error != nil {
 		logger.Error("could not write bytes", "err", err)
 	}
 }
@@ -233,7 +233,7 @@ func (t *HTTPRPC) handleError(err error, codec channel.Codec, req *http.Request,
 		fmt.Fprint(w, "unknown error")
 	}
 
-	if _, error :=w.Write(payload); error != nil {
+	if _, error := w.Write(payload); error != nil {
 		logger.Error("could not write payload", "err", err)
 	}
 }

--- a/pkg/transport/httprpc/httprpc.go
+++ b/pkg/transport/httprpc/httprpc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nanobus/nanobus/pkg/config"
 	"github.com/nanobus/nanobus/pkg/errorz"
 	"github.com/nanobus/nanobus/pkg/handler"
+	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/resolve"
 	"github.com/nanobus/nanobus/pkg/spec"
 	"github.com/nanobus/nanobus/pkg/transport"
@@ -213,7 +214,9 @@ func (t *HTTPRPC) handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(responseBytes)
+	if _, error :=w.Write(responseBytes); error != nil {
+		logger.Error("could not write bytes", "err", err)
+	}
 }
 
 func (t *HTTPRPC) handleError(err error, codec channel.Codec, req *http.Request, w http.ResponseWriter, status int) {
@@ -230,5 +233,7 @@ func (t *HTTPRPC) handleError(err error, codec channel.Codec, req *http.Request,
 		fmt.Fprint(w, "unknown error")
 	}
 
-	w.Write(payload)
+	if _, error :=w.Write(payload); error != nil {
+		logger.Error("could not write payload", "err", err)
+	}
 }

--- a/pkg/transport/nats/nats.go
+++ b/pkg/transport/nats/nats.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/nats-io/nats.go"
 	"go.uber.org/multierr"
-	"go.uber.org/zap"
 
 	"github.com/nanobus/nanobus/pkg/channel"
 	"github.com/nanobus/nanobus/pkg/config"
@@ -146,10 +145,10 @@ func (t *NATS) Listen() error {
 		if err != nil {
 			for _, sub := range subs {
 				if err := sub.Unsubscribe(); err != nil {
-					logger.Error("failed to unsubscribe from NATS", zap.Error(err))
+					logger.Error("failed to unsubscribe from NATS", "error", err)
 				}
 				if err := sub.Drain(); err != nil {
-					logger.Error("failed to drain NATS sub", zap.Error(err))
+					logger.Error("failed to drain NATS sub", "error", err)
 				}
 			}
 			return err
@@ -197,7 +196,7 @@ func (t *NATS) handler(m *nats.Msg) {
 			Data:   []byte(message),
 		}
 		if err := m.RespondMsg(&reply); err != nil {
-			logger.Error("failed to respond to NATS message", zap.Error(err))
+			logger.Error("failed to respond to NATS message", "error", err)
 		}
 		return
 	}
@@ -252,7 +251,7 @@ func (t *NATS) handler(m *nats.Msg) {
 		return
 	}
 	if err := m.RespondMsg(&reply); err != nil {
-		logger.Error("failed to respond to NATS message", zap.Error(err))
+		logger.Error("failed to respond to NATS message", "error", err)
 	}
 }
 
@@ -274,6 +273,6 @@ func (t *NATS) handleError(err error, codec channel.Codec, m *nats.Msg, status i
 		Data:   payload,
 	}
 	if err := m.RespondMsg(&reply); err != nil {
-		logger.Error("failed to respond to NATS message while handling error", zap.Error(err))
+		logger.Error("failed to respond to NATS message while handling error", "error", err)
 	}
 }


### PR DESCRIPTION
This PR:
- Fixes lint errors associated with running `golangci-lint` version `1.50.1`
- Adds `golangci-lint run` to `just test`
- Adds a step to setup `golangci-lint` in CI

This PR mostly adds logging for unchecked errors and removes/comments out unused code as WIP w/TODOs. It's not very aggressive with the default configuration and seemed like a quick win.