### PR TITLE
Fixed structured logging, fixed inconsistent HTTP logging

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,19 +12,19 @@ var sugar zap.SugaredLogger = *initLogger()
 var logger logr.Logger
 
 func Debug(msg string, keysAndValues ...interface{}) {
-	sugar.Debug(append([]interface{}{msg}, keysAndValues...)...)
+	sugar.Debugw(msg, keysAndValues...)
 }
 
 func Info(msg string, keysAndValues ...interface{}) {
-	sugar.Info(append([]interface{}{msg}, keysAndValues...)...)
+	sugar.Infow(msg, keysAndValues...)
 }
 
 func Warn(msg string, keysAndValues ...interface{}) {
-	sugar.Warn(append([]interface{}{msg}, keysAndValues...)...)
+	sugar.Warnw(msg, keysAndValues...)
 }
 
 func Error(msg string, keysAndValues ...interface{}) {
-	sugar.Error(append([]interface{}{msg}, keysAndValues...)...)
+	sugar.Errorw(msg, keysAndValues...)
 }
 
 func initLogger() *zap.SugaredLogger {

--- a/pkg/transport/filter/jwt/jwt.go
+++ b/pkg/transport/filter/jwt/jwt.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/nanobus/nanobus/pkg/config"
 	"github.com/nanobus/nanobus/pkg/errorz"
+	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/resolve"
 	"github.com/nanobus/nanobus/pkg/security/claims"
 	"github.com/nanobus/nanobus/pkg/transport/filter"
@@ -175,7 +176,6 @@ func Filter(log logr.Logger, settings *Settings) filter.Filter {
 			return ctx, nil
 		}
 
-		fmt.Println(tokenString)
 		token, err := jwt.Parse(tokenString, settings.KeyFunc)
 		if err != nil {
 			return nil, errorz.Wrap(err, errorz.Unauthenticated, err.Error())
@@ -187,7 +187,7 @@ func Filter(log logr.Logger, settings *Settings) filter.Filter {
 				ctx = claims.ToContext(ctx, c)
 
 				if settings.Debug {
-					log.Info("Claims debug info [TURN OFF FOR PRODUCTION]",
+					logger.Debug("Claims debug info [TURN OFF FOR PRODUCTION]",
 						"component", "jwt",
 						"claims", c)
 				}

--- a/pkg/transport/http/logger.go
+++ b/pkg/transport/http/logger.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/nanobus/nanobus/pkg/logger"
+)
+
+// This logic is largely taken from gorilla (https://github.com/gorilla/handlers/blob/master/logging.go)
+// which is archived and not taking new PRs.
+
+func LoggingHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		snoop, w := makeLogger(w)
+		next.ServeHTTP(w, r)
+		logger.Debug(r.Method, "path", r.URL.Path, "status", snoop.status)
+	})
+}
+
+type responseLogger struct {
+	w      http.ResponseWriter
+	status int
+	size   int
+}
+
+func (l *responseLogger) Write(b []byte) (int, error) {
+	size, err := l.w.Write(b)
+	l.size += size
+	return size, err
+}
+
+func (l *responseLogger) WriteHeader(s int) {
+	l.w.WriteHeader(s)
+	l.status = s
+}
+
+func (l *responseLogger) Status() int {
+	return l.status
+}
+
+func (l *responseLogger) Size() int {
+	return l.size
+}
+
+func (l *responseLogger) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	conn, rw, err := l.w.(http.Hijacker).Hijack()
+	if err == nil && l.status == 0 {
+		// The status will be StatusSwitchingProtocols if there was no error and
+		// WriteHeader has not been called yet
+		l.status = http.StatusSwitchingProtocols
+	}
+	return conn, rw, err
+}
+func makeLogger(w http.ResponseWriter) (*responseLogger, http.ResponseWriter) {
+	logger := &responseLogger{w: w, status: http.StatusOK}
+	return logger, httpsnoop.Wrap(w, httpsnoop.Hooks{
+		Write: func(httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return logger.Write
+		},
+		WriteHeader: func(httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return logger.WriteHeader
+		},
+	})
+}

--- a/pkg/transport/http/router/static/static.go
+++ b/pkg/transport/http/router/static/static.go
@@ -14,17 +14,16 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"os"
 	"path/filepath"
 	"sort"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 
 	"github.com/nanobus/nanobus/pkg/config"
 	"github.com/nanobus/nanobus/pkg/resolve"
+	nanohttp "github.com/nanobus/nanobus/pkg/transport/http"
 	"github.com/nanobus/nanobus/pkg/transport/http/router"
 )
 
@@ -67,7 +66,7 @@ func NewV1(log logr.Logger, config StaticV1Config) router.Router {
 			if path.Strip != nil {
 				handler = http.StripPrefix(*path.Strip, handler)
 			}
-			r.PathPrefix(path.Path).Handler(handlers.LoggingHandler(os.Stdout, handler))
+			r.PathPrefix(path.Path).Handler(nanohttp.LoggingHandler(handler))
 		}
 
 		return nil


### PR DESCRIPTION
This PR:
- Fixes the structured logging output for the new log level functions to be consistent with what already exists.
- Adds a `LoggingHandler` used by the `static` router so its output will be consistent with the rest of the nanobus logs.
