### PR TITLE
Added `templates/` directory to hold apex templates

### DIFF
--- a/templates/init/.template
+++ b/templates/init/.template
@@ -1,0 +1,2 @@
+name: '@nanobus/init'
+description: Basic NanoBus configuration

--- a/templates/init/bus.yaml.tmpl
+++ b/templates/init/bus.yaml.tmpl
@@ -1,0 +1,10 @@
+id: "{{ .name }}"
+version: 0.0.1
+interfaces:
+  Greeter:
+    SayHello:
+      steps:
+        - name: Say Hello!
+          uses: expr
+          with:
+            value: '"Hello, " + input.name'

--- a/templates/init/justfile
+++ b/templates/init/justfile
@@ -1,0 +1,2 @@
+run:
+  echo '{"name": "World!"}' | nanobus invoke Greeter::SayHello


### PR DESCRIPTION
This PR:
- Adds a basic `init` template to `templates/` to get people started with a working `bus.yaml` and a sample `justfile` that mostly serves as `nanobus invoke` example.