### PR TITLE
Added `id` to iota config

### DIFF
--- a/pkg/runtime/apex.axdl
+++ b/pkg/runtime/apex.axdl
@@ -71,6 +71,8 @@ type BusConfig {
 
 "The configuration for an iota."
 type IotaConfig {
+  "The Iota identifier."
+  id: string
   "The Iota version."
   version: string
   "The iota's executable entrypoint."

--- a/pkg/runtime/generated.go
+++ b/pkg/runtime/generated.go
@@ -83,6 +83,8 @@ type BusConfig struct {
 
 // The configuration for an iota.
 type IotaConfig struct {
+	// The Iota identifier.
+	ID string `json:"id" yaml:"id" msgpack:"id" mapstructure:"id" validate:"required"`
 	// The Iota version.
 	Version string `json:"version" yaml:"version" msgpack:"version" mapstructure:"version" validate:"required"`
 	// The iota's executable entrypoint.


### PR DESCRIPTION
This PR:
- Adds a missing `id` specifier to the iota config.
