### PR TITLE
add option to oauth2 to specify cookie domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/felixge/httpsnoop v1.0.3
 	github.com/go-co-op/gocron v1.18.0
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/pkg/transport/http/router/oauth2/generated.go
+++ b/pkg/transport/http/router/oauth2/generated.go
@@ -18,6 +18,7 @@ type OAuth2V1Config struct {
 	Endpoint     Endpoint         `json:"endpoint" yaml:"endpoint" msgpack:"endpoint" mapstructure:"endpoint"`
 	CallbackURL  string           `json:"callbackUrl" yaml:"callbackUrl" msgpack:"callbackUrl" mapstructure:"callbackUrl" validate:"required"`
 	RedirectURL  string           `json:"redirectUrl" yaml:"redirectUrl" msgpack:"redirectUrl" mapstructure:"redirectUrl" validate:"required"`
+	CookieDomain string           `json:"cookieDomain" yaml:"cookieDomain" msgpack:"cookieDomain" mapstructure:"cookieDomain" validate:"required"`
 	Scopes       []string         `json:"scopes,omitempty" yaml:"scopes,omitempty" msgpack:"scopes,omitempty" mapstructure:"scopes" validate:"dive"`
 	Handler      *handler.Handler `json:"handler,omitempty" yaml:"handler,omitempty" msgpack:"handler,omitempty" mapstructure:"handler"`
 }

--- a/specs/transport/http/oauth2.axdl
+++ b/specs/transport/http/oauth2.axdl
@@ -16,6 +16,7 @@ type OAuth2V1Config @router("nanobus.transport.http.oauth2/v1") {
   endpoint:     Endpoint
   callbackUrl:  string
   redirectUrl:  string = "/"
+  cookieDomain: string
   scopes:       [string]?
   handler:      Handler?
 }


### PR DESCRIPTION
Adding `cookieDomain` option to oauth2.  If no value or empty value is passed, it will default to the domain of the request.