### PR TITLE
oauth2: make cookieDomain optional

### DIFF
--- a/config/ts/components/transport_oauth2.ts
+++ b/config/ts/components/transport_oauth2.ts
@@ -18,6 +18,7 @@ export interface OAuth2V1Config {
   endpoint: Endpoint;
   callbackUrl: string;
   redirectUrl?: string;
+  cookieDomain?: string;
   scopes?: string[];
   handler?: Handler;
 }

--- a/pkg/transport/http/router/oauth2/generated.go
+++ b/pkg/transport/http/router/oauth2/generated.go
@@ -18,7 +18,7 @@ type OAuth2V1Config struct {
 	Endpoint     Endpoint         `json:"endpoint" yaml:"endpoint" msgpack:"endpoint" mapstructure:"endpoint"`
 	CallbackURL  string           `json:"callbackUrl" yaml:"callbackUrl" msgpack:"callbackUrl" mapstructure:"callbackUrl" validate:"required"`
 	RedirectURL  string           `json:"redirectUrl" yaml:"redirectUrl" msgpack:"redirectUrl" mapstructure:"redirectUrl" validate:"required"`
-	CookieDomain string           `json:"cookieDomain" yaml:"cookieDomain" msgpack:"cookieDomain" mapstructure:"cookieDomain" validate:"required"`
+	CookieDomain *string          `json:"cookieDomain,omitempty" yaml:"cookieDomain,omitempty" msgpack:"cookieDomain,omitempty" mapstructure:"cookieDomain"`
 	Scopes       []string         `json:"scopes,omitempty" yaml:"scopes,omitempty" msgpack:"scopes,omitempty" mapstructure:"scopes" validate:"dive"`
 	Handler      *handler.Handler `json:"handler,omitempty" yaml:"handler,omitempty" msgpack:"handler,omitempty" mapstructure:"handler"`
 }

--- a/pkg/transport/http/router/oauth2/oauth2.go
+++ b/pkg/transport/http/router/oauth2/oauth2.go
@@ -52,7 +52,7 @@ type Auth struct {
 	config       *oauth2.Config
 	redirectURL  string
 	userInfoURL  string
-	cookieDomain string
+	cookieDomain *string
 	processor    runtime.Namespaces
 	handler      *handler.Handler
 	debug        bool
@@ -127,8 +127,8 @@ func (o *Auth) AddRoutes(r *mux.Router, address string) error {
 
 func (o *Auth) login(w http.ResponseWriter, r *http.Request) {
 	domain := r.Host
-	if o.cookieDomain != "" {
-		domain = o.cookieDomain
+	if o.cookieDomain != nil {
+		domain = *o.cookieDomain
 	}
 	// Create oauthState cookie
 	oauthState := generateStateOauthCookie(w, domain)

--- a/specs/transport/http/oauth2.axdl
+++ b/specs/transport/http/oauth2.axdl
@@ -16,7 +16,7 @@ type OAuth2V1Config @router("nanobus.transport.http.oauth2/v1") {
   endpoint:     Endpoint
   callbackUrl:  string
   redirectUrl:  string = "/"
-  cookieDomain: string
+  cookieDomain: string?
   scopes:       [string]?
   handler:      Handler?
 }


### PR DESCRIPTION
This PR fixes this error encountered running the NanoChat example.

```sh
could not load transport	{"type": "nanobus.transport.http.server/v1", "error": "Key: 'OAuth2V1Config.CookieDomain' Error:Field validation for 'CookieDomain' failed on the 'required' tag"}
```