### PR TITLE
Create a separate function that stops/cancels the engine's context

### DIFF
--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -68,16 +68,19 @@ func (c *defaultRunCmd) Run() error {
 	if c.Debug {
 		level = zapcore.DebugLevel
 	}
-	if _, err := engine.Start(&engine.Info{
+	e, err := engine.Start(&engine.Info{
 		Mode:          engine.ModeService,
 		BusFile:       "bus.yaml",
 		ResourcesFile: "resources.yaml",
 		LogLevel:      level,
 		DeveloperMode: c.DeveloperMode,
-	}); err != nil {
+	})
+	if err != nil {
 		// Error is logged in `Start`.
 		os.Exit(1)
 	}
+	defer e.Stop()
+
 	return nil
 }
 
@@ -113,17 +116,20 @@ func (c *runCmd) Run() error {
 		level = zapcore.DebugLevel
 	}
 
-	if _, err := engine.Start(&engine.Info{
+	e, err := engine.Start(&engine.Info{
 		Mode:          engine.ModeService,
 		BusFile:       location,
 		LogLevel:      level,
 		ResourcesFile: c.ResourcesFile,
 		Process:       c.Args,
 		DeveloperMode: c.DeveloperMode,
-	}); err != nil {
+	})
+	if err != nil {
 		// Error is logged in `Start`.
 		os.Exit(1)
 	}
+	defer e.Stop()
+
 	return nil
 }
 
@@ -187,6 +193,8 @@ func (c *invokeCmd) Run() error {
 		os.Exit(1)
 		return nil
 	}
+	defer e.Stop()
+
 	var result any
 	result, err = e.InvokeUnsafe(h, input)
 	if err != nil {

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -79,7 +79,12 @@ func (c *defaultRunCmd) Run() error {
 		// Error is logged in `Start`.
 		os.Exit(1)
 	}
-	defer e.Stop()
+	defer func() {
+		err = e.Stop()
+		if err != nil {
+			logger.Error(err.Error())
+		}
+	}()
 
 	return nil
 }
@@ -128,7 +133,12 @@ func (c *runCmd) Run() error {
 		// Error is logged in `Start`.
 		os.Exit(1)
 	}
-	defer e.Stop()
+	defer func() {
+		err = e.Stop()
+		if err != nil {
+			logger.Error(err.Error())
+		}
+	}()
 
 	return nil
 }
@@ -193,7 +203,12 @@ func (c *invokeCmd) Run() error {
 		os.Exit(1)
 		return nil
 	}
-	defer e.Stop()
+	defer func() {
+		err = e.Stop()
+		if err != nil {
+			logger.Error(err.Error())
+		}
+	}()
 
 	var result any
 	result, err = e.InvokeUnsafe(h, input)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -151,6 +151,7 @@ type Info struct {
 
 type Engine struct {
 	ctx            context.Context
+	cancel         context.CancelFunc
 	log            logr.Logger
 	tracer         trace.Tracer
 	actionRegistry actions.Registry
@@ -160,6 +161,8 @@ type Engine struct {
 	m              *mesh.Mesh
 	allNamespaces  runtime.Namespaces
 	codec          channel.Codec
+
+	transportInvoker transport.Invoker
 }
 
 func (e *Engine) LoadConfig(busConfig *runtime.BusConfig) error {
@@ -244,7 +247,6 @@ func (e *Engine) LoadConfig(busConfig *runtime.BusConfig) error {
 
 func Start(info *Info) (*Engine, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	// If there is a `.env` file, load its environment variables.
 	if err := godotenv.Load(); err != nil {
@@ -554,6 +556,7 @@ func Start(info *Info) (*Engine, error) {
 
 	e := Engine{
 		ctx:            ctx,
+		cancel:         cancel,
 		log:            log,
 		tracer:         tracer,
 		actionRegistry: actionRegistry,
@@ -752,6 +755,7 @@ func Start(info *Info) (*Engine, error) {
 
 		return response, err
 	}
+	e.transportInvoker = transportInvoker
 	dependencies["transport:invoker"] = transport.Invoker(transportInvoker)
 
 	if info.Mode == ModeService {
@@ -829,23 +833,17 @@ func Start(info *Info) (*Engine, error) {
 	return &e, nil
 }
 
-func (e *Engine) invoke(handler handler.Handler, input any, authmode transport.Authorization) (any, error) {
-	var transportInvoker transport.Invoker
-	if err := resolve.Resolve(e.resolveAs,
-		"transport:invoker", &transportInvoker,
-	); err != nil {
-		return nil, err
-	}
-
-	return transportInvoker(e.ctx, handler, "", input, authmode)
+func (e *Engine) Stop() error {
+	e.cancel()
+	return nil
 }
 
 func (e *Engine) InvokeUnsafe(handler handler.Handler, input any) (any, error) {
-	return e.invoke(handler, input, transport.BypassAuthorization)
+	return e.transportInvoker(e.ctx, handler, "", input, transport.BypassAuthorization)
 }
 
 func (e *Engine) Invoke(handler handler.Handler, input any) (any, error) {
-	return e.invoke(handler, input, transport.PerformAuthorization)
+	return e.transportInvoker(e.ctx, handler, "", input, transport.PerformAuthorization)
 }
 
 func loadResourcesConfig(filename string, log logr.Logger) (*runtime.ResourcesConfig, error) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -246,7 +246,13 @@ func (e *Engine) LoadConfig(busConfig *runtime.BusConfig) error {
 }
 
 func Start(info *Info) (*Engine, error) {
+	keepContext := false
 	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if !keepContext {
+			cancel()
+		}
+	}()
 
 	// If there is a `.env` file, load its environment variables.
 	if err := godotenv.Load(); err != nil {
@@ -828,6 +834,8 @@ func Start(info *Info) (*Engine, error) {
 				log.Error(err, "unexpected error")
 			}
 		}
+	} else {
+		keepContext = true
 	}
 
 	return &e, nil


### PR DESCRIPTION
When using `nanobus invoke <operation>` with configurations that contain resources (e.g. database), a `context canceled` error was returned. This PR fixes that by moving the call to the `context.CancelFn` to a `Stop` function.