### PR TITLE
Tweaks for blog example

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -9,6 +9,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 )
 
 func TestInvoke(t *testing.T) {
+	ctx := context.Background()
 	var input any = map[string]interface{}{
 		"name": "World",
 	}
@@ -30,7 +32,7 @@ func TestInvoke(t *testing.T) {
 		EntityID:      "nothing",
 		DeveloperMode: false,
 	}
-	engine, err := Start(&info)
+	engine, err := Start(ctx, &info)
 	assert.NoError(t, err)
 	response, err := engine.Invoke(handler, input)
 	assert.Error(t, err)


### PR DESCRIPTION
This PR makes a few tweaks so that the blogs examples works via invoke and as a service.

* Add support for streams to write to stdout via `nanobus invoke`
* Pass in context to engine
* Postgres query returns a slice if a stream is not in the context