### PR TITLE
Add positional argument to nanobus run that support registry path and bus.yaml path

### DIFF
--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -126,6 +126,7 @@ func (c *runCmd) Run() error {
 		LogLevel:      level,
 		ResourcesFile: c.ResourcesFile,
 		PackageFile:   reference,
+		Process:       c.Args,
 		DeveloperMode: c.DeveloperMode,
 	}); err != nil {
 		// Error is logged in `Start`.

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -79,6 +79,7 @@ func (c *defaultRunCmd) Run() error {
 		Mode:          engine.ModeService,
 		BusFile:       "bus.yaml",
 		ResourcesFile: "resources.yaml",
+		PackageFile:   "",
 		LogLevel:      level,
 		DeveloperMode: c.DeveloperMode,
 	}); err != nil {
@@ -96,6 +97,8 @@ type runCmd struct {
 	BusFile string `name:"bus" default:"bus.yaml" help:"The application configuration or OCI image reference"`
 	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
 	ResourcesFile string `name:"resources" default:"resources.yaml" help:"The resources configuration"`
+	// PackageFile is the resources configuration (e.g. databases, message brokers).
+	PackageFile string `name:"package" optional:"" help:"The registry hosted pacakage containing a packaged NanoBus application"`
 	// Turns on debug logging.
 	Debug bool `name:"debug" help:"Turns on debug logging"`
 	// Args are arguments passed to the application.
@@ -130,6 +133,7 @@ func (c *runCmd) Run() error {
 		BusFile:       location,
 		LogLevel:      level,
 		ResourcesFile: c.ResourcesFile,
+		PackageFile:   c.PackageFile,
 		Process:       c.Args,
 		DeveloperMode: c.DeveloperMode,
 	}); err != nil {
@@ -149,6 +153,8 @@ type invokeCmd struct {
 	BusFile string `name:"bus" default:"bus.yaml" help:"The NanoBus application configuration"`
 	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
 	ResourcesFile string `name:"resources" default:"resources.yaml" help:"The resources configuration"`
+	// PackageFile is the resources configuration (e.g. databases, message brokers).
+	PackageFile string `name:"package" optional:"" help:"The registry hosted pacakage containing a packaged NanoBus application"`
 	// EntityID is the entity identifier to invoke.
 	EntityID string `name:"id" optional:"" help:"The entity ID to invoke (e.g. actor ID)"`
 	// Input is the file to use as JSON input.
@@ -198,6 +204,7 @@ func (c *invokeCmd) Run() error {
 		BusFile:       c.BusFile,
 		LogLevel:      level,
 		ResourcesFile: c.ResourcesFile,
+		PackageFile:   c.PackageFile,
 		EntityID:      c.EntityID,
 		DeveloperMode: c.DeveloperMode,
 	}
@@ -293,9 +300,9 @@ func (c *pushCmd) Run() error {
 
 	reference := fmt.Sprintf("%s/%s/%s:%s", registry, org, applicationID, conf.Version)
 	if c.DryRun {
-		fmt.Printf("Pushing %s (dry run)...\n", reference)
+		fmt.Printf("Pushing %s (dry run)\n", reference)
 	} else {
-		fmt.Printf("Pushing %s...\n", reference)
+		fmt.Printf("Pushing %s\n", reference)
 	}
 
 	add := conf.Package.Add

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -92,7 +92,7 @@ func (c *defaultRunCmd) Run() error {
 }
 
 type runCmd struct {
-	Target        string `arg:"positional" required:"" help:"The application configuration yaml file or OCI image reference."`
+	Target        string `arg:"positional" optional:"" help:"The application configuration yaml file or OCI image reference."`
 	DeveloperMode bool   `name:"developer-mode" help:"Enables developer mode."`
 	// BusFile of the application as a configuration yaml file.
 	BusFile string `name:"bus" default:"bus.yaml" help:"The application configuration yaml file."`

--- a/cmd/nanobus/main.go
+++ b/cmd/nanobus/main.go
@@ -77,9 +77,8 @@ func (c *defaultRunCmd) Run() error {
 	}
 	if _, err := engine.Start(ctx, &engine.Info{
 		Mode:          engine.ModeService,
-		BusFile:       "bus.yaml",
+		Target:        "bus.yaml",
 		ResourcesFile: "resources.yaml",
-		PackageFile:   "",
 		LogLevel:      level,
 		DeveloperMode: c.DeveloperMode,
 	}); err != nil {
@@ -92,14 +91,10 @@ func (c *defaultRunCmd) Run() error {
 }
 
 type runCmd struct {
-	Target        string `arg:"positional" optional:"" help:"The application configuration yaml file or OCI image reference."`
+	Target        string `arg:"positional" required:"" help:"The application configuration yaml file or OCI image reference."`
 	DeveloperMode bool   `name:"developer-mode" help:"Enables developer mode."`
-	// BusFile of the application as a configuration yaml file.
-	BusFile string `name:"bus" default:"bus.yaml" help:"The application configuration yaml file."`
 	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
 	ResourcesFile string `name:"resources" default:"resources.yaml" help:"The resources configuration"`
-	// PackageFile is the resources configuration (e.g. databases, message brokers).
-	PackageFile string `name:"package" optional:"" help:"The registry hosted pacakage containing a packaged NanoBus application"`
 	// Turns on debug logging.
 	Debug bool `name:"debug" help:"Turns on debug logging"`
 	// Args are arguments passed to the application.
@@ -113,6 +108,8 @@ func (c *runCmd) Run() error {
 	var reference string
 	if oci.IsImageReference(c.Target) {
 		reference = c.Target
+	} else {
+		reference = "bus.yaml"
 	}
 
 	level := zapcore.InfoLevel
@@ -122,10 +119,9 @@ func (c *runCmd) Run() error {
 
 	if _, err := engine.Start(ctx, &engine.Info{
 		Mode:          engine.ModeService,
-		BusFile:       c.BusFile,
+		Target:        reference,
 		LogLevel:      level,
 		ResourcesFile: c.ResourcesFile,
-		PackageFile:   reference,
 		Process:       c.Args,
 		DeveloperMode: c.DeveloperMode,
 	}); err != nil {
@@ -138,15 +134,12 @@ func (c *runCmd) Run() error {
 }
 
 type invokeCmd struct {
-	DeveloperMode bool `name:"developer-mode" help:"Enables developer mode."`
+	Target        string `arg:"positional" required:"" help:"The application configuration yaml file or OCI image reference."`
+	DeveloperMode bool   `name:"developer-mode" help:"Enables developer mode."`
 	// Operation is the operation name.
 	Operation string `arg:"" required:"" help:"The operation or function invoke"`
-	// BusFile is the application configuration (not an OCI image reference).
-	BusFile string `name:"bus" default:"bus.yaml" help:"The NanoBus application configuration"`
 	// ResourcesFile is the resources configuration (e.g. databases, message brokers).
 	ResourcesFile string `name:"resources" default:"resources.yaml" help:"The resources configuration"`
-	// PackageFile is the resources configuration (e.g. databases, message brokers).
-	PackageFile string `name:"package" optional:"" help:"The registry hosted pacakage containing a packaged NanoBus application"`
 	// EntityID is the entity identifier to invoke.
 	EntityID string `name:"id" optional:"" help:"The entity ID to invoke (e.g. actor ID)"`
 	// Input is the file to use as JSON input.
@@ -193,10 +186,9 @@ func (c *invokeCmd) Run() error {
 
 	info := engine.Info{
 		Mode:          engine.ModeInvoke,
-		BusFile:       c.BusFile,
+		Target:        c.Target,
 		LogLevel:      level,
 		ResourcesFile: c.ResourcesFile,
-		PackageFile:   c.PackageFile,
 		EntityID:      c.EntityID,
 		DeveloperMode: c.DeveloperMode,
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -260,24 +260,29 @@ func Start(ctx context.Context, info *Info) (*Engine, error) {
 	}
 	// NanoBus flags
 	// Pull from registry if PackageFile is set
-	var location string
+	var busFile string
 	if oci.IsImageReference(info.PackageFile) {
 		fmt.Printf("Pulling %s...\n", info.PackageFile)
 		var err error
-		if location, err = oci.Pull(info.PackageFile, "."); err != nil {
+		if busFile, err = oci.Pull(info.PackageFile, "."); err != nil {
 			fmt.Printf("Error pulling image: %s\n", err)
 			return nil, err
 		}
-		if location == "" {
-			// Fallback to default application config filename.
-			location = "bus.yaml"
+
+		if busFile == "" {
+			fmt.Printf("Error in package: %s\n", "No BusFile returned")
+			return nil, err
 		}
 	}
 
+	if busFile == "" {
+		busFile = info.BusFile
+	}
+
 	// Load the bus configuration
-	busConfig, err := loadBusConfig(info.BusFile, log)
+	busConfig, err := loadBusConfig(busFile, log)
 	if err != nil {
-		log.Error(err, "could not load configuration", "file", info.BusFile)
+		log.Error(err, "could not load configuration", "file", busFile)
 		return nil, err
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -138,9 +138,8 @@ const (
 
 type Info struct {
 	Mode          Mode
-	BusFile       string
+	Target        string
 	ResourcesFile string
-	PackageFile   string
 	DeveloperMode bool
 	LogLevel      zapcore.Level
 
@@ -261,10 +260,10 @@ func Start(ctx context.Context, info *Info) (*Engine, error) {
 	// NanoBus flags
 	// Pull from registry if PackageFile is set
 	var busFile string
-	if oci.IsImageReference(info.PackageFile) {
-		fmt.Printf("Pulling %s...\n", info.PackageFile)
+	if oci.IsImageReference(info.Target) {
+		fmt.Printf("Pulling %s...\n", info.Target)
 		var err error
-		if busFile, err = oci.Pull(info.PackageFile, "."); err != nil {
+		if busFile, err = oci.Pull(info.Target, "."); err != nil {
 			fmt.Printf("Error pulling image: %s\n", err)
 			return nil, err
 		}
@@ -276,7 +275,7 @@ func Start(ctx context.Context, info *Info) (*Engine, error) {
 	}
 
 	if busFile == "" {
-		busFile = info.BusFile
+		busFile = info.Target
 	}
 
 	// Load the bus configuration

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -27,9 +27,8 @@ func TestInvoke(t *testing.T) {
 	info := Info{
 		Mode:          ModeInvoke,
 		LogLevel:      zapcore.ErrorLevel,
-		BusFile:       "test-data/greeter.yaml",
+		Target:        "test-data/greeter.yaml",
 		ResourcesFile: "",
-		PackageFile:   "",
 		EntityID:      "nothing",
 		DeveloperMode: false,
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -29,6 +29,7 @@ func TestInvoke(t *testing.T) {
 		LogLevel:      zapcore.ErrorLevel,
 		BusFile:       "test-data/greeter.yaml",
 		ResourcesFile: "",
+		PackageFile:   "",
 		EntityID:      "nothing",
 		DeveloperMode: false,
 	}


### PR DESCRIPTION
Adds option so a single command can run directly from the registry without doing a separate `nanobus pull`.

example: `nanobus run reg.candle.run/myorg/myapp:0.0.1`