### PR TITLE
Added check for docker config file for credentials

### DIFF
--- a/docsite/docs/deployment-options.mdx
+++ b/docsite/docs/deployment-options.mdx
@@ -41,30 +41,42 @@ services:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nanobus-app
+  name: candle-site
+  namespace: candle-site
 spec:
   selector:
     matchLabels:
-      app: nanobus-app
-  replicas: 1
+      app: candle-site
+  replicas: 2
   template:
     metadata:
       labels:
-        app: nanobus-app
+        app: candle-site
     spec:
+      nodeSelector:
+        agentpool: platpool
       containers:
-        - name: nanobus-app
+        - name: candle-site
           resources:
             limits:
               memory: "128Mi"
-              cpu: "100m"
-          image: nanobus/nanobus:latest
+              cpu: "500m"
+          image: nanobus/nanobus:v0.0.16
           args:
             - "run"
-            - "OCI package reference"
+            - "reg.candle.run/candlecorp/candle-site:0.0.0"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          #The following is only needed if you are trying to download from a private project/org on your registry.
+          volumeMounts:
+            - mountPath: /.docker/config.json
+              name: docker-config
+              subPath: .dockerconfigjson
+      volumes: 
+        - name: docker-config
+          secret:
+            secretName: registry-secret #created using "kubectl create secret docker-registry"
 ```
 
 ## Nomad

--- a/docsite/docs/oci-package.mdx
+++ b/docsite/docs/oci-package.mdx
@@ -26,7 +26,11 @@ package:
 
 ## Credentials / Pushing
 
-Currently, you need to have the credentials stored as environment variables (if you are not using the GitHub action).
+### Docker Config File
+NanoBus will by default read the credentials if any are stored in your `$HOME/.docker/config.json` file.
+
+### ENV Variables
+If there are any credentials stored in the config file, they will be used first.  If you want to override the config file, you can set the following environment variables:
 ```
 export OCI_REGISTRIES=MYREG
 export MYREG_HOSTNAME=reg.candle.run

--- a/pkg/oci/remote.go
+++ b/pkg/oci/remote.go
@@ -57,7 +57,7 @@ func getRepository(reference string) (*remote.Repository, error) {
 			}
 		}
 	} else if os.IsNotExist(err) {
-		fmt.Println(configFile, " does not exist.")
+		fmt.Println(configFile, " does not exist. Checking for environment variables.")
 	} else {
 		fmt.Println("Error checking ", configFile, err)
 	}
@@ -74,6 +74,7 @@ func getRepository(reference string) (*remote.Repository, error) {
 			password := os.Getenv(registry + "_PASSWORD")
 
 			if hostname != "" && username != "" && password != "" {
+				fmt.Println("Adding ", hostname, " credentials from ENV")
 				if _, ok := repos[hostname]; ok {
 					fmt.Println("ENV Registry credentials overwriting config file credentials for: ", registry)
 				}

--- a/pkg/oci/remote.go
+++ b/pkg/oci/remote.go
@@ -37,19 +37,19 @@ func getRepository(reference string) (*remote.Repository, error) {
 	if _, err := os.Stat(configFile); err == nil {
 		contents, err := os.ReadFile(configFile)
 		if err != nil {
-			fmt.Println("Error reading config file:", err)
+			fmt.Println("Error reading ", configFile, err)
 			return nil, err
 		}
 
 		var config configs
 		if err := json.Unmarshal(contents, &config); err != nil {
-			fmt.Println("Error parsing config file:", err)
+			fmt.Println("Error parsing ", configFile, err)
 			return nil, err
 		}
 
 		for registry, authconfigs := range config.Auths {
 			if authconfigs.Username != "" && authconfigs.Password != "" {
-				fmt.Println("Adding registry credentials from file: ", registry)
+				fmt.Println("Adding ", registry, " credentials from ", configFile)
 				repos[registry] = auth.Credential{
 					Username: authconfigs.Username,
 					Password: authconfigs.Password,
@@ -57,9 +57,9 @@ func getRepository(reference string) (*remote.Repository, error) {
 			}
 		}
 	} else if os.IsNotExist(err) {
-		fmt.Println(configFile, "file does not exist.")
+		fmt.Println(configFile, " does not exist.")
 	} else {
-		fmt.Println("Error checking config file:", err)
+		fmt.Println("Error checking ", configFile, err)
 	}
 
 	registriesString := os.Getenv("OCI_REGISTRIES")
@@ -74,7 +74,7 @@ func getRepository(reference string) (*remote.Repository, error) {
 			password := os.Getenv(registry + "_PASSWORD")
 
 			if hostname != "" && username != "" && password != "" {
-				if repos[hostname].Username != "" {
+				if _, ok := repos[hostname]; ok {
 					fmt.Println("ENV Registry credentials overwriting config file credentials for: ", registry)
 				}
 				repos[hostname] = auth.Credential{

--- a/pkg/oci/remote.go
+++ b/pkg/oci/remote.go
@@ -1,9 +1,11 @@
 package oci
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"oras.land/oras-go/v2/registry/remote"
@@ -14,8 +16,52 @@ var (
 	ErrNotAnOCIImage = errors.New("not an OCI image")
 )
 
+type configs struct {
+	Auths map[string]struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		Email    string `json:"email"`
+		Auth     string `json:"auth"`
+	} `json:"auths"`
+}
+
 func getRepository(reference string) (*remote.Repository, error) {
 	repos := make(map[string]auth.Credential)
+
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	configFile := filepath.Join(homedir, ".docker/config.json")
+	if _, err := os.Stat(configFile); err == nil {
+		contents, err := os.ReadFile(configFile)
+		if err != nil {
+			fmt.Println("Error reading config file:", err)
+			return nil, err
+		}
+
+		var config configs
+		if err := json.Unmarshal(contents, &config); err != nil {
+			fmt.Println("Error parsing config file:", err)
+			return nil, err
+		}
+
+		for registry, authconfigs := range config.Auths {
+			if authconfigs.Username != "" && authconfigs.Password != "" {
+				fmt.Println("Adding registry credentials from file: ", registry)
+				repos[registry] = auth.Credential{
+					Username: authconfigs.Username,
+					Password: authconfigs.Password,
+				}
+			}
+		}
+	} else if os.IsNotExist(err) {
+		fmt.Println(configFile, "file does not exist.")
+	} else {
+		fmt.Println("Error checking config file:", err)
+	}
+
 	registriesString := os.Getenv("OCI_REGISTRIES")
 
 	if registriesString != "" {
@@ -28,6 +74,9 @@ func getRepository(reference string) (*remote.Repository, error) {
 			password := os.Getenv(registry + "_PASSWORD")
 
 			if hostname != "" && username != "" && password != "" {
+				if repos[hostname].Username != "" {
+					fmt.Println("ENV Registry credentials overwriting config file credentials for: ", registry)
+				}
 				repos[hostname] = auth.Credential{
 					Username: username,
 					Password: password,


### PR DESCRIPTION
Address Issue 109.

This will allow users to store their registry credentials in $HOME/.docker/config.json file and Nanobus will read those values.  The ENV variables will also be iterated and if there is an overlap, may overwrite the values from the docker file.