### PR TITLE
Scheduler repeat

### DIFF
--- a/pkg/transport/time/generated.go
+++ b/pkg/transport/time/generated.go
@@ -18,4 +18,5 @@ func SchedulerV1() (string, transport.Loader) {
 type Schedule struct {
 	Schedule string          `json:"schedule" yaml:"schedule" msgpack:"schedule" mapstructure:"schedule" validate:"required"`
 	Handler  handler.Handler `json:"handler" yaml:"handler" msgpack:"handler" mapstructure:"handler" validate:"required"`
+	Repeat   uint8           `json:"repeat" yaml:"repeat" msgpack:"repeat" mapstructure:"repeat"`
 }

--- a/pkg/transport/time/generated.go
+++ b/pkg/transport/time/generated.go
@@ -18,5 +18,5 @@ func SchedulerV1() (string, transport.Loader) {
 type Schedule struct {
 	Schedule string          `json:"schedule" yaml:"schedule" msgpack:"schedule" mapstructure:"schedule" validate:"required"`
 	Handler  handler.Handler `json:"handler" yaml:"handler" msgpack:"handler" mapstructure:"handler" validate:"required"`
-	Repeat   uint8           `json:"repeat" yaml:"repeat" msgpack:"repeat" mapstructure:"repeat"`
+	Repeat   uint64          `json:"repeat" yaml:"repeat" msgpack:"repeat" mapstructure:"repeat"`
 }

--- a/pkg/transport/time/scheduler.go
+++ b/pkg/transport/time/scheduler.go
@@ -76,12 +76,23 @@ func (t *Scheduler) Listen() error {
 	for _, sched := range t.schedules {
 		if err := func(sched Schedule) error {
 			t.log.Info("Scheduling", "schedule", sched.Schedule, "handler", sched.Handler)
-			_, err := s.Cron(sched.Schedule).LimitRunsTo(int(sched.Repeat)).Do(func() {
-				_, err := t.invoker(t.ctx, sched.Handler, t.id, input, transport.BypassAuthorization)
-				if err != nil {
-					t.log.Error(err, "Error in %q", sched.Handler)
-				}
-			})
+
+			var err error
+			if sched.Repeat > 0 {
+				_, err = s.Cron(sched.Schedule).LimitRunsTo(int(sched.Repeat)).Do(func() {
+					_, err := t.invoker(t.ctx, sched.Handler, t.id, input, transport.BypassAuthorization)
+					if err != nil {
+						t.log.Error(err, "Error in %q", sched.Handler)
+					}
+				})
+			} else {
+				_, err = s.Cron(sched.Schedule).Do(func() {
+					_, err := t.invoker(t.ctx, sched.Handler, t.id, input, transport.BypassAuthorization)
+					if err != nil {
+						t.log.Error(err, "Error in %q", sched.Handler)
+					}
+				})
+			}
 			if err != nil {
 				t.log.Error(err, "Could not schedule", "schedule", sched.Schedule)
 				return err

--- a/pkg/transport/time/scheduler.go
+++ b/pkg/transport/time/scheduler.go
@@ -76,7 +76,7 @@ func (t *Scheduler) Listen() error {
 	for _, sched := range t.schedules {
 		if err := func(sched Schedule) error {
 			t.log.Info("Scheduling", "schedule", sched.Schedule, "handler", sched.Handler)
-			_, err := s.Cron(sched.Schedule).Do(func() {
+			_, err := s.Cron(sched.Schedule).LimitRunsTo(int(sched.Repeat)).Do(func() {
 				_, err := t.invoker(t.ctx, sched.Handler, t.id, input, transport.BypassAuthorization)
 				if err != nil {
 					t.log.Error(err, "Error in %q", sched.Handler)

--- a/specs/transport/time/scheduler.axdl
+++ b/specs/transport/time/scheduler.axdl
@@ -51,6 +51,7 @@ app.transport(
 }
 
 type Schedule {
-  schedule:    string
-  handler:    Handler
+  schedule:     string
+  handler:      Handler
+  repeat:       u8 = 0 # 0 = infinite
 }

--- a/specs/transport/time/scheduler.axdl
+++ b/specs/transport/time/scheduler.axdl
@@ -53,5 +53,5 @@ app.transport(
 type Schedule {
   schedule:     string
   handler:      Handler
-  repeat:       u8 = 0 # 0 = infinite
+  repeat:       u64 = 0 # 0 = infinite
 }


### PR DESCRIPTION
Added `repeat` configuration to scheduler.  Will allow the scheduler to specify the number of times a task should be repeated.  0 (default) means indefinite.