### PR TITLE
Removed early finish on small reads, fixes #133

### DIFF
--- a/pkg/actions/blob/write.go
+++ b/pkg/actions/blob/write.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nanobus/nanobus/pkg/codec"
 	"github.com/nanobus/nanobus/pkg/config"
 	"github.com/nanobus/nanobus/pkg/expr"
+	"github.com/nanobus/nanobus/pkg/logger"
 	"github.com/nanobus/nanobus/pkg/resiliency"
 	"github.com/nanobus/nanobus/pkg/resolve"
 	"github.com/nanobus/nanobus/pkg/resource"
@@ -68,6 +69,7 @@ func WriteAction(
 		if err != nil {
 			return nil, fmt.Errorf("could not evaluate key: %w", err)
 		}
+		logger.Debug("@blob/write", "key", key)
 
 		// Note: writer.Close seems to fail due to "context closed"
 		// if `ctx` is used. Even if the context is not done prior.


### PR DESCRIPTION
This PR:
- Adds debug logging to @blob/read & @blob/write
- Removes logic that closes a read early if a read is less than the buffer size. The next loop will read `0` or EOF if it's truly done.