### PR TITLE
Fix for loading components from relative paths

### DIFF
--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -36,7 +36,7 @@ func NormalizeUrl(url string, base ...string) (string, error) {
 	if err != nil || normalUrl.Scheme == "" {
 		if strings.HasPrefix(url, "/") {
 			normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", url))
-		} else if strings.HasPrefix(url, ".") {
+		} else if !strings.Contains(url, "..") {
 			normalUrl, err = URL.Parse(fmt.Sprintf("file:///%s", path.Join(baseUrl, url)))
 		}
 	}


### PR DESCRIPTION
The path should be normalized for relative FS paths even if they do not have a `./` prefix. Adding a check to prevent `..` for now as that seems dangerous.